### PR TITLE
Add mosquitto-clients to tedge-full-image

### DIFF
--- a/images/\
+++ b/images/\
@@ -10,5 +10,5 @@ IMAGE_INSTALL += " \
                 tedge-apt-plugin \
                 tedge-dummy-plugin \
                 tedge-watchdog \
-		mosquitto-clients \
+		mosquitto-clients
 "


### PR DESCRIPTION
As this is the full image, we can add the `mosquito-clients` package which includes `mosquitto_pub` and `mosquitto_sub` programs to have some debugging capabilities.

Signed-off-by: Marcel Guzik <marcel.guzik@inetum.com>