### PR TITLE
Removed dependency to mender-state-scripts

### DIFF
--- a/recipes-tedge/tedge-state-scripts/tedge-state-scripts_1.0.bb
+++ b/recipes-tedge/tedge-state-scripts/tedge-state-scripts_1.0.bb
@@ -1,5 +1,3 @@
-inherit mender-state-scripts
-
 LICENSE = "CLOSED"
 
 SRC_URI += " \


### PR DESCRIPTION
This change removes dependency to mender-state-scripts. Without this, building the "plain" meta-tedge required also Mender client layer.