### PR TITLE
add recipe to use compiled binaries

### DIFF
--- a/tedge-prebuilt/conf/layer.conf
+++ b/tedge-prebuilt/conf/layer.conf
@@ -1,0 +1,10 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH := "${BBPATH}:${LAYERDIR}"
+
+# We have a packages directory, add to BBFILES
+BBFILES := "${BBFILES} ${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "tedge"
+BBFILE_PATTERN_tedge := "^${LAYERDIR}/"
+BBFILE_PRIORITY_tedge = "6"

--- a/tedge-prebuilt/recipes-core/tedge-core/tedge-aarch64.bb
+++ b/tedge-prebuilt/recipes-core/tedge-core/tedge-aarch64.bb
@@ -1,0 +1,11 @@
+CHANNEL = "main"
+VERSION = "0.12.1-rc374+g5d57ed1"
+
+require tedge.inc
+
+SRC_URI = "https://dl.cloudsmith.io/public/thinedge/tedge-${CHANNEL}/raw/names/tedge-arm64/versions/${VERSION}/tedge.tar.gz"
+
+SRC_URI[md5sum] = "8ccf8b73541a1f8d232a5af8bd8f2759"
+SRC_URI[sha256sum] = "4dc9902a4f8ce8ca57d420c20cbb1fa39a796516d38846c48c3a6f7d7d9b4c1b"
+
+COMPATIBLE_HOST = "(aarch64.*-linux)"

--- a/tedge-prebuilt/recipes-core/tedge-core/tedge-x86-64.bb
+++ b/tedge-prebuilt/recipes-core/tedge-core/tedge-x86-64.bb
@@ -1,0 +1,11 @@
+CHANNEL = "main"
+VERSION = "0.12.1-rc374+g5d57ed1"
+
+require tedge.inc
+
+SRC_URI = "https://dl.cloudsmith.io/public/thinedge/tedge-${CHANNEL}/raw/names/tedge-amd64/versions/${VERSION}/tedge.tar.gz"
+
+SRC_URI[md5sum] = "819fda04f4104f2e536fffff20062bc6"
+SRC_URI[sha256sum] = "8688de3decc51ce803056b8dcd8bc8b82ad93ba229bb6ec544ca86cf48bff1c0"
+
+COMPATIBLE_HOST = "(x86_64.*-linux)"

--- a/tedge-prebuilt/recipes-core/tedge-core/tedge.bb
+++ b/tedge-prebuilt/recipes-core/tedge-core/tedge.bb
@@ -1,0 +1,23 @@
+# Automatically choose tedge package based on target architecture
+def get_tedge_pkg(d):
+	TA = d.getVar('TARGET_ARCH', True)
+	if TA == "arm":
+		FPU = d.getVar('TARGET_FPU', True)
+		if FPU == "soft":
+			tedgePkg = "tedge-armv6"
+		else:
+			tedgePkg = "tedge-armv7"
+    elif TA == "aarch64":
+        tedgePkg = "tedge-aarch64"
+	elif TA == "i586":
+		tedgePkg = "tedge-i586"
+	elif TA == "x86_64":
+		tedgePkg = "tedge-x86-64"
+	else:
+		raise bb.parse.SkipPackage("Target architecture '%s' is not supported by the meta-tedge layer" %TA)
+
+	return tedgePkg
+
+TEDGE_PKG = "${@get_tedge_pkg(d)}"
+
+require ${TEDGE_PKG}.inc

--- a/tedge-prebuilt/recipes-core/tedge-core/tedge.inc
+++ b/tedge-prebuilt/recipes-core/tedge-core/tedge.inc
@@ -1,0 +1,29 @@
+LICENSE_FLAGS = "tedge"
+
+FETCHCMD_wget_append = " --no-check-certificate "
+
+RDEPENDS_${PN} += " mosquitto"
+S = "${WORKDIR}"
+
+do_install () {
+    install -d -m 0755 ${D}
+}
+
+# All the files are provided in a binary package, and keeping all the
+# files in a single package causes packaging QA errors and warnings.
+# Avoid these packaging failure by skipping all the QA checks
+INSANE_SKIP_${PN} = "${ERROR_QA} ${WARN_QA}"
+
+# Inhibit warnings about files being stripped, we can't do anything about it.
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
+PACKAGES = "${PN}-sources ${PN}"
+
+RPROVIDES_${PN} = "tedge"
+PROVIDES += "tedge"
+
+inherit update-alternatives
+
+pkg_postinst_${PN} () {
+    ${bindir}/tedge init
+}


### PR DESCRIPTION
WIP: Explore the possibility to reduce the complexity to install thin-edge.io during a yocto build by using the official pre-compiled binaries instead of building everything (due to complexities/incompatibilities by cargo-bitbake and meta-rust).