### PR TITLE
Set fix uid/gid of mosquitto on recipe level

### DIFF
--- a/docs/install-mender.md
+++ b/docs/install-mender.md
@@ -131,16 +131,6 @@ IMAGE_INSTALL:append = " \
 "
 ```
 
-You must set fixed uid/gid to avoid permissions problems on the `/data` partition. You can do that by inheriting the `extrausers` class in your image recipe or the `local.conf` file:
-
-```
-inherit extrausers
-EXTRA_USERS_PARAMS = "\
-    groupmod -g 960 mosquitto; \
-    usermod -u 961 mosquitto; \
-"
-```
-
 We recommend switching to `Network Manager`. Append your `local.conf` with the following recipes:
 
 ```

--- a/recipes-connectivity/mosquitto/mosquitto_%.bbappend
+++ b/recipes-connectivity/mosquitto/mosquitto_%.bbappend
@@ -1,0 +1,5 @@
+inherit useradd
+
+# Used fix uid/gid to avoid permission problems on /data
+GROUPADD_PARAM:${PN} = "--system --gid 960 mosquitto"
+USERADD_PARAM:${PN} = "--system --no-create-home --shell /bin/false --uid 961 --gid 960 mosquitto"

--- a/recipes-core/images/core-image-tedge-mender.bb
+++ b/recipes-core/images/core-image-tedge-mender.bb
@@ -11,10 +11,3 @@ IMAGE_INSTALL:append = " \
     networkmanager-bash-completion \
     networkmanager-nmtui \
 "
-
-inherit extrausers
-# Used fix uid/gid to avoid permission problems on /data
-EXTRA_USERS_PARAMS = "\
-    groupmod -g 960 mosquitto; \
-    usermod -u 961 mosquitto; \
-"


### PR DESCRIPTION
This PR changes the way we set fix uid and gid for mosquitto user. Currently, we do at image recipe level by using `extrausers` class which requires users to put additional effort if they want to go with their own image. I moved this logic to mosquitto recipes  using bbappend file. Mosquitto is using `useradd` class anyway, so we only need to edit params with static gid/uid. 