### PR TITLE
chore: update for thin-edge.io 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The repository follows the release-named branch strategy. Only LTS releases are 
 | Yocto Release | thin-edge version | Branch Name | Branch Status |
 | :- | :- | :- | :- |
 | Scarthgap | 1.0.1 | scarthgap | Active and maintained |
-| Kirkstone | 1.0.1 | kirkstone | Active and maintained |
+| Kirkstone | 1.1.0 | kirkstone | Active and maintained |
 
 ## Dependencies
 

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
@@ -69,7 +69,7 @@ pkg_postinst_ontarget:${PN} () {
     fi
 
     # reduce number of packages shown (supported only from >= 1.1.0)
-    tedge config set software.plugin.exclude "^(glibc|lib|kernel-|iptables-module).*" ||:
+    tedge config set software.plugin.exclude "^(glibc|lib|kernel-|iptables-module).*" || true
 }
 
 # Automatically choose tedge package based on target architecture

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
@@ -67,6 +67,9 @@ pkg_postinst_ontarget:${PN} () {
     if command -v c8y-remote-access-plugin >/dev/null 2>&1; then
         c8y-remote-access-plugin --init
     fi
+
+    # reduce number of packages shown (supported only from >= 1.1.0)
+    tedge config set software.plugin.exclude "^(glibc|lib|kernel-|iptables-module).*" ||:
 }
 
 # Automatically choose tedge package based on target architecture

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.1.0.bb
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.1.0.bb
@@ -1,0 +1,16 @@
+# Architecture variables
+ARCH_REPO_CHANNEL = "release"
+ARCH_VERSION = "1.1.0"
+SRC_URI[aarch64.md5sum] = "b8b9941cdf026cfde9a650c06cd12a9e"
+SRC_URI[armv6.md5sum] = "e673ec9de42b59cfe2cdba2aa7492012"
+SRC_URI[armv7.md5sum] = "d67d2e98da8f627bfa321655022cd769"
+SRC_URI[x86_64.md5sum] = "fc86e95c1d75a9a715d768ceb649e070"
+
+# Init manager variables
+INIT_REPO_CHANNEL = "community"
+INIT_VERSION = "0.4.1"
+SRC_URI[openrc.md5sum] = "1852d7742cb8ffcf0eb765b43895912d"
+SRC_URI[systemd.md5sum] = "67e02f3c03145eada06525f8df39813f"
+SRC_URI[sysvinit.md5sum] = "bed2e55a38a560b3ac4c0baa796b33ee"
+
+require tedge.inc

--- a/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware/firmware_update.mender.toml
+++ b/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware/firmware_update.mender.toml
@@ -1,4 +1,4 @@
-#:schema https://gist.githubusercontent.com/reubenmiller/4e28e8403fe0c54b7461ac7d1d6838c2/raw/b8599ccf81120bb22bdaa164655e2cc0b8fcb902/tedge.workflow.json
+#:schema https://gist.githubusercontent.com/reubenmiller/4e28e8403fe0c54b7461ac7d1d6838c2/raw/4ad7e3bc3ce2e3a7542a5b4873a0196cbe91f35d/tedge.workflow.json
 operation = "firmware_update"
 on_error = "failed"
 
@@ -25,8 +25,11 @@ on_exit.4 = { status = "restart", reason = "Install was successful, rebooting de
 on_exit._ = { status = "failed", reason = "Verification failed, no rollback necessary" }
 
 [restart]
-action = "restart"
-on_exec = "restarting"  # Internal state used by the "restart" action
+operation = "restart"
+on_exec = "await_restart"
+
+[await_restart]
+action = "await-operation-completion"
 on_success = "restarted"
 on_error = { status = "failed", reason = "Failed to restart device" }
 
@@ -43,8 +46,11 @@ on_exit.2 = { status = "failed", reason = "Nothing to commit. Either the boot lo
 on_exit._ = { status = "rollback_restart", reason = "Mender commit failed. Rolling back to previous partition" }
 
 [rollback_restart]
-action = "restart"
-on_exec = "restarting"  # Internal state used by the "restart" action
+operation = "restart"
+on_exec = "await_rollback_restart"
+
+[await_rollback_restart]
+action = "await-operation-completion"
 on_success = "rollback_successful"
 
 [rollback_successful]

--- a/meta-tedge-rauc/recipes-tedge/tedge-firmware-rauc/tedge-firmware-rauc/firmware_update.rauc.toml
+++ b/meta-tedge-rauc/recipes-tedge/tedge-firmware-rauc/tedge-firmware-rauc/firmware_update.rauc.toml
@@ -1,4 +1,4 @@
-#:schema https://gist.githubusercontent.com/reubenmiller/4e28e8403fe0c54b7461ac7d1d6838c2/raw/b8599ccf81120bb22bdaa164655e2cc0b8fcb902/tedge.workflow.json
+#:schema https://gist.githubusercontent.com/reubenmiller/4e28e8403fe0c54b7461ac7d1d6838c2/raw/4ad7e3bc3ce2e3a7542a5b4873a0196cbe91f35d/tedge.workflow.json
 operation = "firmware_update"
 on_error = "failed"
 
@@ -25,8 +25,11 @@ on_exit.4 = { status = "restart", reason = "Install was successful, rebooting de
 on_exit._ = { status = "failed", reason = "Verification failed, no rollback necessary" }
 
 [restart]
-action = "restart"
-on_exec = "restarting"  # Internal state used by the "restart" action
+operation = "restart"
+on_exec = "await_restart"
+
+[await_restart]
+action = "await-operation-completion"
 on_success = "restarted"
 on_error = { status = "failed", reason = "Failed to restart device" }
 
@@ -53,8 +56,11 @@ on_success = { status = "rollback_restart" }
 on_error = { status = "rollback_restart" }
 
 [rollback_restart]
-action = "restart"
-on_exec = "restarting"  # Internal state used by the "restart" action
+operation = "restart"
+on_exec = "await_rollback_restart"
+
+[await_rollback_restart]
+action = "await-operation-completion"
 on_success = "rollback_successful"
 
 [rollback_successful]

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -98,7 +98,7 @@ pkg_postinst_ontarget:${PN} () {
     fi
 
     # reduce number of packages shown (supported only from >= 1.1.0)
-    tedge config set software.plugin.exclude "^(glibc|lib|kernel-|iptables-module).*" ||:
+    tedge config set software.plugin.exclude "^(glibc|lib|kernel-|iptables-module).*" || true
 }
 
 FILES:${PN} = "\ 

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -96,6 +96,9 @@ pkg_postinst_ontarget:${PN} () {
     if command -v c8y-remote-access-plugin >/dev/null 2>&1; then
         c8y-remote-access-plugin --init
     fi
+
+    # reduce number of packages shown (supported only from >= 1.1.0)
+    tedge config set software.plugin.exclude "^(glibc|lib|kernel-|iptables-module).*" ||:
 }
 
 FILES:${PN} = "\ 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.1.0.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.1.0.bb
@@ -1,0 +1,12 @@
+SRCREV_tedge = "ea66825c0f83d48a1fe8c38acce8765fe172b22c"
+SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_FORMAT = "tedge"
+S = "${WORKDIR}/git"
+
+SRC_URI += "\
+file://0003-Cargo.toml-do-not-strip.patch \
+"
+
+TEDGE_EXCLUDE = "c8y-firmware-plugin"
+
+require tedge.inc


### PR DESCRIPTION
Prepare for 1.1.0 thin-edge.io release

Checklist

* [x] update workflows to use thin-edge.io 1.1.0 sub workflow syntax
* [x] add package exclude filter (new in 1.1.0)
* [x] Add new release artifacts for meta-tedge-bin
* [x] Add new release artifacts for meta-tedge