### PR TITLE
fix: add tedge-write to suoders file to enable writing configuration files

### DIFF
--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
@@ -25,7 +25,7 @@ do_install:append () {
 pkg_postinst_ontarget:${PN} () {
     ### Create file in /etc/sudoers.d directory. With this configuration, the tedge user have the right to call the tedge command with sudo rights, which is required for system-wide configuration in "/etc/tedge"
     if [ -d /etc/sudoers.d ]; then
-        echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge
+        echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /usr/bin/tedge-write /etc/*, /usr/bin/tedge-write /data/*" >/etc/sudoers.d/tedge
 
         if [ -f "/etc/sudoers.d/010_pi-nopasswd" ]; then
             echo "tedge   ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge-nopasswd

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -54,7 +54,7 @@ do_install:append () {
 pkg_postinst_ontarget:${PN} () {
     ### Create file in /etc/sudoers.d directory. With this configuration, the tedge user have the right to call the tedge command with sudo rights, which is required for system-wide configuration in "/etc/tedge"
     if [ -d /etc/sudoers.d ]; then
-        echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge
+        echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /usr/bin/tedge-write /etc/*, /usr/bin/tedge-write /data/*" >/etc/sudoers.d/tedge
 
         if [ -f "/etc/sudoers.d/010_pi-nopasswd" ]; then
             echo "tedge   ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge-nopasswd


### PR DESCRIPTION
Adding `tedge-write` to the sudoers file to enable writing configuration files under /etc and /data/