### PR TITLE
ci: add missing GH_TOKEN env variable for gh cli

### DIFF
--- a/.github/workflows/check_updates.yml
+++ b/.github/workflows/check_updates.yml
@@ -16,7 +16,7 @@ jobs:
         run: ./scripts/admin.sh update_version
       - name: Create PR on new version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -x
           git add -A . ||:


### PR DESCRIPTION
gh now requires `GH_TOKEN` when used in github workflows:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```