### PR TITLE
ci: add missing gh token env variable to the workflow step

### DIFF
--- a/.github/workflows/check_updates.yml
+++ b/.github/workflows/check_updates.yml
@@ -13,10 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check update
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/admin.sh update_version
       - name: Create PR on new version
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -x
           git add -A . ||:


### PR DESCRIPTION
(second attempt): Add missing gh token env variable to a previous step