### PR TITLE
fix: change default rust version to 1.78

### DIFF
--- a/meta-tedge/conf/layer.conf
+++ b/meta-tedge/conf/layer.conf
@@ -20,4 +20,4 @@ LAYERDEPENDS_meta-tedge = "core networking-layer rust-layer"
 
 LAYERSERIES_COMPAT_meta-tedge = "kirkstone"
 
-RUSTVERSION ?= "1.75.0"
+RUSTVERSION ?= "1.78.0"


### PR DESCRIPTION
Set default RUSTVERSION to 1.78 to align with thin-edge.io 1.2.0 which has a MSRV of 1.78