### PR TITLE
fix: publish event updates to configured tedge topic identifier

### DIFF
--- a/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware/mender_workflow.sh
+++ b/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware/mender_workflow.sh
@@ -19,13 +19,19 @@ fi
 ACTION="$1"
 shift
 
+# Get tedge topic identifier
+TOPIC_ROOT=$(tedge config get mqtt.topic_root)
+TOPIC_ID=$(tedge config get mqtt.device_topic_id)
+
 log() {
     msg="$(date +%Y-%m-%dT%H:%M:%S) [current=$ACTION] $*"
     echo "$msg" >&2
 
     # publish to pub for better resolution
     current_partition=$(get_current_partition)
-    tedge mqtt pub -q 2 te/device/main///e/firmware_update "{\"text\":\"Firmware Workflow: [$ACTION] $*\",\"state\":\"$ACTION\",\"partition\":\"$current_partition\"}"
+    if ! tedge mqtt pub -q 2 "$TOPIC_ROOT/$TOPIC_ID/e/firmware_update" "{\"text\":\"Firmware Workflow: [$ACTION] $*\",\"state\":\"$ACTION\",\"partition\":\"$current_partition\"}"; then
+        echo "$(date +%Y-%m-%dT%H:%M:%S) [current=$ACTION] WARNING: Failed to publish MQTT message" >&2
+    fi
     sleep 1
 }
 


### PR DESCRIPTION
Fix a bug where the firmware update status assumed it was always running on the main device.

Now the firmware status update (sent as events), are published to the configured mqtt root topic and topic identifier.