### PR TITLE
feat: add support for riscv architectures to meta-tedge-bin layer

### DIFF
--- a/meta-tedge-bin/recipes-tedge/tedge-bin/architectures/tedge-riscv64.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/architectures/tedge-riscv64.inc
@@ -1,0 +1,2 @@
+SRC_URI += "https://dl.cloudsmith.io/public/thinedge/tedge-${ARCH_REPO_CHANNEL}/raw/names/tedge-riscv64/versions/${ARCH_VERSION}/tedge.tar.gz;name=riscv64;subdir=${BP}/usr/bin"
+COMPATIBLE_HOST = "(riscv64|riscv32).*"

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
@@ -3,6 +3,7 @@ HOMEPAGE = "https://thin-edge.io"
 LICENSE = "CLOSED"
 RDEPENDS:${PN} += " mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo"
 
+inherit logging
 inherit bin_package useradd
 
 INSANE_SKIP:${PN} = "already-stripped"
@@ -85,8 +86,11 @@ def get_tedge_pkg(d):
         tedgePkg = "tedge-aarch64"
     elif target == "x86_64":
         tedgePkg = "tedge-x86-64"
+    elif target == "riscv64" or target == "riscv64gc":
+        tedgePkg = "tedge-riscv64"
     else:
-        raise bb.parse.SkipPackage("Target architecture '%s' is not supported by the meta-tedge-bin layer" %target)
+        bb.warn("Target architecture '%s' is not supported by the meta-tedge-bin layer" % target)
+        raise bb.parse.SkipPackage("Target architecture '%s' is not supported by the meta-tedge-bin layer" % target)
     return tedgePkg
 
 # Automatically setup service system based on init manager
@@ -99,7 +103,8 @@ def get_tedge_service(d):
     elif "systemd" in initManager:
         tedgeService = "tedge-systemd"
     else:
-        raise bb.parse.SkipPackage("Init manager '%s' is not supported by the meta-tedge-bin layer" %initManager)
+        bb.warn("Init manager '%s' is not supported by the meta-tedge-bin layer" % initManager)
+        raise bb.parse.SkipPackage("Init manager '%s' is not supported by the meta-tedge-bin layer" % initManager)
     return tedgeService
 
 TEDGE_PKG = "${@get_tedge_pkg(d)}"

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.3.1.bb
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.3.1.bb
@@ -5,6 +5,7 @@ SRC_URI[aarch64.md5sum] = "0006c47d48ae214c236a07f863bb533b"
 SRC_URI[armv6.md5sum] = "1892147ece0872665e323d00d3fd79e1"
 SRC_URI[armv7.md5sum] = "8208b9e107805d4459a9b99ca195a766"
 SRC_URI[x86_64.md5sum] = "c8b256a1cdef070b7d6bd1a2102f7460"
+SRC_URI[riscv64.md5sum] = "d87b064d5054e43cad6a2476a2fbc871"
 
 # Init manager variables
 INIT_REPO_CHANNEL = "community"

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -87,6 +87,7 @@ SRC_URI[aarch64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_chan
 SRC_URI[armv6.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}-armv6" "armv6" "$tedge_version")"
 SRC_URI[armv7.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "armv7" "$tedge_version")"
 SRC_URI[x86_64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "amd64" "$tedge_version")"
+SRC_URI[riscv64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "riscv64" "$tedge_version")"
 
 # Init manager variables
 INIT_REPO_CHANNEL = "$(basename "$community_repo")"


### PR DESCRIPTION
Add support for installing the pre-compiled riscv thin-edge.io artifacts.

Explicit warning messages were added if the CPU architecture is not supported to make it easier to debug as the the `skipPackage` function was not printing out the given reason to the build log.