### PR TITLE
fix(mender): remove networkmanager dependency from mender image

### DIFF
--- a/meta-tedge-mender/recipes-core/images/core-image-tedge-mender.bb
+++ b/meta-tedge-mender/recipes-core/images/core-image-tedge-mender.bb
@@ -4,10 +4,3 @@ IMAGE_INSTALL:append = " \
     tedge-state-scripts \
     tedge-firmware \
 "
-
-# Add Network Manager
-IMAGE_INSTALL:append = " \ 
-    networkmanager \
-    networkmanager-bash-completion \
-    networkmanager-nmtui \
-"


### PR DESCRIPTION
Removing the networkmanager dependency from the mender core image as not all users want this.