### PR TITLE
feat(mender): stream download when using mender 4.x

### DIFF
--- a/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware.bb
+++ b/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware.bb
@@ -37,7 +37,7 @@ do_install () {
 
     # Allow sudo access
     install -d -m 0750 "${D}/etc/sudoers.d"
-    echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/mender, /usr/bin/tedgectl" > ${D}${sysconfdir}/sudoers.d/tedge-firmware
+    install -m 0644 "${WORKDIR}/tedge-firmware" "${D}${sysconfdir}/sudoers.d/"
 
     # FIXME: Check if there is a better place to do this
     if [ -d "${D}/var/lib/mosquitto" ]; then

--- a/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware/mender_workflow.sh
+++ b/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware/mender_workflow.sh
@@ -178,13 +178,16 @@ download() {
     # Auto detect based on the url if the direct url can be used or not
     case "$url" in
         */inventory/binaries/*)
-            # FUTURE: The mender client 3.x currently checks for a Content-Length header in the response
-            # and fails if it is not present. Cumulocity IoT uses chunked Transfter-Encoding where the Content-Length
-            # is no included in the response headers, thus causing mender to fail.
-            # mender is currently being rewritten and seems to have support for proper Content-Range handling, however
-            # it is still in alpha.
+            # NOTE: The mender client 3.x currently checks for a Content-Length header in the response
+            # and fails if it is not present. Cumulocity IoT uses chunked Transfer-Encoding where the Content-Length
+            # is not included in the response headers, thus causing mender to fail, so the artifact must be downloaded
+            # manually.
             #
-            MANUAL_DOWNLOAD=1
+            # mender-update (aka mender 4.x) does not have this limitation.
+            #
+            if [ "$MENDER_CLI" = "mender" ]; then
+                MANUAL_DOWNLOAD=1
+            fi
             tedge_url=$(convert_tedge_url "$url")
             ;;
     esac

--- a/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware/tedge-firmware
+++ b/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware/tedge-firmware
@@ -1,1 +1,1 @@
-tedge  ALL = (ALL) NOPASSWD: /usr/bin/mender, /etc/tedge/operations/mender_workflow.sh, /usr/bin/tedgectl
+tedge  ALL = (ALL) NOPASSWD: /usr/bin/mender, /usr/bin/mender-update, /etc/tedge/operations/mender_workflow.sh, /usr/bin/tedgectl

--- a/meta-tedge-mender/recipes-tedge/tedge-state-scripts/tedge-state-scripts/transfer
+++ b/meta-tedge-mender/recipes-tedge/tedge-state-scripts/tedge-state-scripts/transfer
@@ -86,8 +86,9 @@ fi
 
 # sudoers
 if [ -d /etc/sudoers.d ]; then
+    # Don't clobber any existing files
     progress "Copying sudoers.d config"
-    cp -af /etc/sudoers.d/* "${target}/etc/sudoers.d/"
+    cp -an /etc/sudoers.d/* "${target}/etc/sudoers.d/"
 fi
 
 # mosquitto

--- a/meta-tedge-rauc/recipes-tedge/rauc-bundle/files/hook.sh
+++ b/meta-tedge-rauc/recipes-tedge/rauc-bundle/files/hook.sh
@@ -47,8 +47,9 @@ transfer_files() {
 
     # sudoers
     if [ -d /etc/sudoers.d ]; then
+        # Don't clobber any existing files
         progress "Copying sudoers.d config"
-        cp -af /etc/sudoers.d/* "${target}/etc/sudoers.d/"
+        cp -an /etc/sudoers.d/* "${target}/etc/sudoers.d/"
     fi
 
 


### PR DESCRIPTION
Mender 4.x should support content range headers again (this was broken in mender 3.x), so allow mender to download the artifact itself when downloading from a Cumulocity URL (e.g. c8y local proxy url), when using the mender 4.x client.

During testing the following fixes were also applied
* mender: don't overwrite sudoers files that exist in the new image (as this prevents the image adding new fixes)
* rauc: don't overwrite sudoers files that exist in the new image (as this prevents the image adding new fixes)