### PR TITLE
feat: allow users to enable/disable tedge services

### DIFF
--- a/meta-tedge-extras/recipes-tedge/tedge-container-plugin/common.inc
+++ b/meta-tedge-extras/recipes-tedge/tedge-container-plugin/common.inc
@@ -8,7 +8,7 @@ do_install:append () {
     # Service files
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
 		install -d ${D}${systemd_system_unitdir}
-        install -m 0755 ${S}/src/${GO_IMPORT}/packaging/services/systemd/tedge-container-plugin.service ${D}${systemd_system_unitdir}
+        install -m 0644 ${S}/src/${GO_IMPORT}/packaging/services/systemd/tedge-container-plugin.service ${D}${systemd_system_unitdir}
         
 	elif ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'true', 'false', d)}; then
         install -d ${D}${sysconfdir}/init.d
@@ -17,7 +17,7 @@ do_install:append () {
 
     # configuration
     install -m 0755 -d ${D}${sysconfdir}/tedge-container-plugin
-    install -m 0755 ${S}/src/${GO_IMPORT}/packaging/config.toml ${D}${sysconfdir}/tedge-container-plugin/
+    install -m 0644 ${S}/src/${GO_IMPORT}/packaging/config.toml ${D}${sysconfdir}/tedge-container-plugin/
 
     # Rename the binary
     mv ${D}${bindir}/tedge-container-plugin ${D}${bindir}/tedge-container

--- a/meta-tedge/recipes-tedge/tedge/tedge-services.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-services.inc
@@ -9,7 +9,7 @@ do_install:append () {
         for service in ${WORKDIR}/tedge-services/services/systemd/system/*.service; do
             filename=$(basename "$service" ".service")
             if ${@bb.utils.contains('TEDGE_EXCLUDE', "$filename", 'false', 'true', d)}; then
-                install -m 0755 $service ${D}${systemd_system_unitdir}
+                install -m 0644 $service ${D}${systemd_system_unitdir}
             fi
         done 
 	elif ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'true', 'false', d)}; then

--- a/meta-tedge/recipes-tedge/tedge/tedge-services.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-services.inc
@@ -8,7 +8,7 @@ do_install:append () {
 		install -d ${D}${systemd_system_unitdir}
         for service in ${WORKDIR}/tedge-services/services/systemd/system/*.service; do
             filename=$(basename "$service" ".service")
-            if ${@bb.utils.contains('TEDGE_EXCLUDE', '$filename', 'false', 'true', d)}; then
+            if ${@bb.utils.contains('TEDGE_EXCLUDE', "$filename", 'false', 'true', d)}; then
                 install -m 0755 $service ${D}${systemd_system_unitdir}
             fi
         done 
@@ -16,7 +16,7 @@ do_install:append () {
         install -d ${D}${sysconfdir}/init.d
         for service in ${WORKDIR}/tedge-services/services/sysvinit-yocto/init.d/*; do
             filename=$(basename -- "$service")
-            if ${@bb.utils.contains('TEDGE_EXCLUDE', '$filename', 'false', 'true', d)}; then
+            if ${@bb.utils.contains('TEDGE_EXCLUDE', "$filename", 'false', 'true', d)}; then
                 install -m 0755 $service ${D}${sysconfdir}/init.d
             fi
         done 

--- a/meta-tedge/recipes-tedge/tedge/tedge-services.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-services.inc
@@ -34,10 +34,41 @@ do_install:append () {
     fi
 }
 
+PACKAGES += "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-c8y-firmware-plugin"
+
 FILES:${PN} += "\
-    ${systemd_system_unitdir}/* \
     ${sysconfdir}/init.d/* \
     ${TEDGE_CONFIG_DIR}/system.toml \
     ${sysconfdir}/tedgectl/env \
     ${bindir}/tedgectl \
 "
+
+FILES:${PN}-agent += "\
+    ${systemd_system_unitdir}/tedge-agent.service \
+"
+FILES:${PN}-mapper-c8y += "\
+    ${systemd_system_unitdir}/tedge-mapper-c8y.service \
+"
+FILES:${PN}-mapper-aws += "\
+    ${systemd_system_unitdir}/tedge-mapper-aws.service \
+"
+FILES:${PN}-mapper-az += "\
+    ${systemd_system_unitdir}/tedge-mapper-az.service \
+"
+FILES:${PN}-mapper-collectd += "\
+    ${systemd_system_unitdir}/tedge-mapper-collectd.service \
+"
+FILES:${PN}-c8y-firmware-plugin += "\
+    ${systemd_system_unitdir}/c8y-firmware-plugin.service \
+"
+
+SYSTEMD_PACKAGES = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-c8y-firmware-plugin"
+SYSTEMD_SERVICE:${PN}-agent = "tedge-agent.service"
+SYSTEMD_SERVICE:${PN}-mapper-c8y = "tedge-mapper-c8y.service"
+SYSTEMD_SERVICE:${PN}-mapper-aws = "tedge-mapper-aws.service"
+SYSTEMD_SERVICE:${PN}-mapper-az = "tedge-mapper-az.service"
+SYSTEMD_SERVICE:${PN}-mapper-collectd = "tedge-mapper-collectd.service"
+SYSTEMD_SERVICE:${PN}-c8y-firmware-plugin = "c8y-firmware-plugin.service"
+
+# Disable c8y-firmware-plugin as this is deprecated
+SYSTEMD_AUTO_ENABLE:${PN}-c8y-firmware-plugin = "disable"

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -16,7 +16,7 @@ LICENSE = "Apache-2.0"
 inherit logging
 inherit cargo useradd
 
-RDEPENDS:${PN} = " mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo collectd"
+RDEPENDS:${PN} = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo collectd"
 
 # This prevents disabling crates.io registry in cargo_do_configure task and
 # allows cargo to fetch dependencies during the do_compile step.


### PR DESCRIPTION
Users can now enable/disable services using standard yocto `SYSTEMD_AUTO_ENABLE` variable:

**Example (local.conf)**

```
SYSTEMD_AUTO_ENABLE:tedge-mapper-c8y = "enable"
SYSTEMD_AUTO_ENABLE:tedge-mapper-aws = "enable"
SYSTEMD_AUTO_ENABLE:tedge-mapper-az = "enable"
SYSTEMD_AUTO_ENABLE:tedge-mapper-collectd = "enable"
SYSTEMD_AUTO_ENABLE:tedge-agent = "enable"
```