### PR TITLE
feat: c8y-remote-access-plugin socket activated service when using systemd

### DIFF
--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.3.1.bb
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.3.1.bb
@@ -9,9 +9,9 @@ SRC_URI[riscv64.md5sum] = "d87b064d5054e43cad6a2476a2fbc871"
 
 # Init manager variables
 INIT_REPO_CHANNEL = "community"
-INIT_VERSION = "0.5.2"
-SRC_URI[openrc.md5sum] = "efb47032defb0177c2f9320e4fdf78e0"
-SRC_URI[systemd.md5sum] = "a8674b153e30d46e4b8b013fc141eefb"
-SRC_URI[sysvinit.md5sum] = "c1697c4b5bed190527a822fbc9bfeabd"
+INIT_VERSION = "0.6.0"
+SRC_URI[openrc.md5sum] = "515bfcb3ff01cb6929dda6c6922eb7a7"
+SRC_URI[systemd.md5sum] = "579cf149b89256fb83c7eb44aa45ccb1"
+SRC_URI[sysvinit.md5sum] = "493f1a2e66fa3e154c558b138e5da6bf"
 
 require tedge.inc

--- a/meta-tedge/recipes-tedge/tedge/tedge-services.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-services.inc
@@ -6,8 +6,8 @@ inherit ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'update-rc.d', '', d
 do_install:append () {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
 		install -d ${D}${systemd_system_unitdir}
-        for service in ${WORKDIR}/tedge-services/services/systemd/system/*.service; do
-            filename=$(basename "$service" ".service")
+        for service in ${WORKDIR}/tedge-services/services/systemd/system/*; do
+            filename=$(basename "$service" ".service" | cut -d. -f1)
             if ${@bb.utils.contains('TEDGE_EXCLUDE', "$filename", 'false', 'true', d)}; then
                 install -m 0644 $service ${D}${systemd_system_unitdir}
             fi

--- a/meta-tedge/recipes-tedge/tedge/tedge-services.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-services.inc
@@ -48,6 +48,8 @@ FILES:${PN}-agent += "\
 "
 FILES:${PN}-mapper-c8y += "\
     ${systemd_system_unitdir}/tedge-mapper-c8y.service \
+    ${systemd_system_unitdir}/c8y-remote-access-plugin@.service \
+    ${systemd_system_unitdir}/c8y-remote-access-plugin.socket \
 "
 FILES:${PN}-mapper-aws += "\
     ${systemd_system_unitdir}/tedge-mapper-aws.service \
@@ -64,7 +66,7 @@ FILES:${PN}-c8y-firmware-plugin += "\
 
 SYSTEMD_PACKAGES = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-c8y-firmware-plugin"
 SYSTEMD_SERVICE:${PN}-agent = "tedge-agent.service"
-SYSTEMD_SERVICE:${PN}-mapper-c8y = "tedge-mapper-c8y.service"
+SYSTEMD_SERVICE:${PN}-mapper-c8y = "tedge-mapper-c8y.service c8y-remote-access-plugin@.service c8y-remote-access-plugin.socket"
 SYSTEMD_SERVICE:${PN}-mapper-aws = "tedge-mapper-aws.service"
 SYSTEMD_SERVICE:${PN}-mapper-az = "tedge-mapper-az.service"
 SYSTEMD_SERVICE:${PN}-mapper-collectd = "tedge-mapper-collectd.service"


### PR DESCRIPTION
Enable the systemd socket activated service to launch c8y-remote-access-plugin connections which are independent of the tedge-mapper-c8y. This enables the connection (e.g. an ssh session) to restart the mapper.

Resolves https://github.com/thin-edge/meta-tedge/issues/84