### PR TITLE
feat: add c8y-command-plugin

### DIFF
--- a/meta-tedge-common/recipes-core/images/core-image-tedge.bb
+++ b/meta-tedge-common/recipes-core/images/core-image-tedge.bb
@@ -2,6 +2,7 @@ require recipes-core/images/core-image-base.bb
 
 IMAGE_INSTALL:append = " \
     tedge \
+    c8y-command-plugin \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'tedge-bootstrap', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'tedge-sethostname', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'tedge-inventory', '', d)} \

--- a/meta-tedge-common/recipes-tedge/c8y-command-plugin/c8y-command-plugin_git.bb
+++ b/meta-tedge-common/recipes-tedge/c8y-command-plugin/c8y-command-plugin_git.bb
@@ -1,0 +1,34 @@
+SRC_URI += "git://git@github.com/thin-edge/c8y-command-plugin.git;protocol=https;branch=main"
+SRCREV = "${AUTOREV}"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = " \
+    file://LICENSE;md5=6c62433ad04bcb1d1c596bc77d409f42 \
+"
+
+inherit allarch
+
+PV = "0.0.2+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += " tedge"
+RDEPENDS:${PN} += " tedge"
+
+TEDGE_CONFIG_DIR ?= "/etc/tedge"
+
+do_install () {
+    install -d "${D}${bindir}"
+    install -d "${D}${TEDGE_CONFIG_DIR}/operations/c8y"
+    install -d "${D}${sysconfdir}/c8y-command-plugin"
+
+    install -m 0644 "${S}/src/c8y_Command" "${D}${TEDGE_CONFIG_DIR}/operations/c8y/"
+    install -m 0755 "${S}/src/c8y-command" "${D}${bindir}/"
+    install -m 0755 "${S}/src/env" "${D}${sysconfdir}/c8y-command-plugin/"
+}
+
+FILES:${PN} += " \
+    ${TEDGE_CONFIG_DIR}/operations/c8y/c8y_Command \
+    ${bindir}/c8y-command \
+    ${sysconfdir}/c8y-command-plugin/env \
+"


### PR DESCRIPTION
Include the [c8y-command-plugin](https://github.com/thin-edge/c8y-command-plugin) with core image.