### PR TITLE
feat: copy plugin configuration if not present

### DIFF
--- a/meta-tedge-mender/recipes-tedge/tedge-state-scripts/tedge-state-scripts/transfer
+++ b/meta-tedge-mender/recipes-tedge/tedge-state-scripts/tedge-state-scripts/transfer
@@ -136,6 +136,12 @@ if [ -d /etc/tedge ]; then
     fi
 fi
 
+# copy default tedge plugin configuration (from readonly rootfs)
+if [ -d "${target}/etc/tedge-default/plugins" ] && [ -d "/data/tedge/plugins" ]; then
+    progress "Copying default plugin configurations from ${target}/etc/tedge-default/plugins to /data/tedge/plugins/ (no clobber)"
+    cp -npv "${target}/etc/tedge-default/plugins/"* "/data/tedge/plugins/" ||:
+fi
+
 # ssh authorized keys
 if [ -d /home/root/.ssh ]; then
     if [ -f /home/root/.ssh/authorized_keys ]; then


### PR DESCRIPTION
In read-only setups, added plugin configuration will be copied to the target tedge plugins configuration file on updates