### PR TITLE
feat: add mosquitto listener for the container network

### DIFF
--- a/meta-tedge-extras/recipes-containers/tedge/tedge_%.bbappend
+++ b/meta-tedge-extras/recipes-containers/tedge/tedge_%.bbappend
@@ -1,0 +1,18 @@
+# Add a dedicate mosquitto mqtt listener to allow communication from containers
+TEDGE_CONTAINER_MQTT_LISTENER_IP ?= "172.17.0.1"
+TEDGE_CONTAINER_MQTT_LISTENER_PORT ?= "1884"
+
+do_install:append () {
+    # Add dedicated listener for the docker traffic
+    if [ -n "${TEDGE_CONTAINER_MQTT_LISTENER_IP}" ] && [ -n "${TEDGE_CONTAINER_MQTT_LISTENER_PORT}" ]; then
+        cat <<EOT > ${D}${TEDGE_CONFIG_DIR}/mosquitto-conf/tedge-networkcontainer.conf
+listener ${TEDGE_CONTAINER_MQTT_LISTENER_PORT} ${TEDGE_CONTAINER_MQTT_LISTENER_IP}
+allow_anonymous true
+require_certificate false
+EOT
+    fi
+}
+
+FILES:${PN} += " \
+    ${TEDGE_CONFIG_DIR}/mosquitto-conf/tedge-networkcontainer.conf \
+"

--- a/meta-tedge-mender/recipes-tedge/tedge-state-scripts/tedge-state-scripts/transfer
+++ b/meta-tedge-mender/recipes-tedge/tedge-state-scripts/tedge-state-scripts/transfer
@@ -142,6 +142,11 @@ if [ -d "${target}/etc/tedge-default/plugins" ] && [ -d "/data/tedge/plugins" ];
     cp -npv "${target}/etc/tedge-default/plugins/"* "/data/tedge/plugins/" ||:
 fi
 
+if [ -d "${target}/etc/tedge-default/mosquitto-conf" ] && [ -d "/data/tedge/mosquitto-conf" ]; then
+    progress "Copying default mosquitto configurations from ${target}/etc/tedge-default/mosquitto-conf to /data/tedge/mosquitto-conf/ (no clobber)"
+    cp -npv "${target}/etc/tedge-default/mosquitto-conf/"* "/data/tedge/mosquitto-conf/" ||:
+fi
+
 # ssh authorized keys
 if [ -d /home/root/.ssh ]; then
     if [ -f /home/root/.ssh/authorized_keys ]; then

--- a/meta-tedge-rauc/recipes-tedge/rauc-bundle/files/hook.sh
+++ b/meta-tedge-rauc/recipes-tedge/rauc-bundle/files/hook.sh
@@ -110,6 +110,11 @@ transfer_files() {
         cp -npv "${target}/etc/tedge-default/plugins/"* "/data/tedge/plugins/" ||: >> "$LOG_FILE" 2>&1
     fi
 
+    if [ -d "${target}/etc/tedge-default/mosquitto-conf" ] && [ -d "/data/tedge/mosquitto-conf" ]; then
+        progress "Copying default mosquitto configurations from ${target}/etc/tedge-default/mosquitto-conf to /data/tedge/mosquitto-conf/ (no clobber)"
+        cp -npv "${target}/etc/tedge-default/mosquitto-conf/"* "/data/tedge/mosquitto-conf/" ||:
+    fi
+
     # ssh authorized keys
     if [ -d /home/root/.ssh ]; then
         if [ -f /home/root/.ssh/authorized_keys ]; then


### PR DESCRIPTION
Add additional mosquitto listener for the container network, to allow deployed containers easy access to the MQTT broker via port 1884 (without having to bind the listener to all interfaces using 0.0.0.0)