### PR TITLE
fix: patch mosquitto service to prevent systemd from disabling service

### DIFF
--- a/meta-tedge-common/recipes-connectivity/mosquitto/mosquitto/0001-set-restart-sec-to-prevent-systemd-prevent-the-servi.patch
+++ b/meta-tedge-common/recipes-connectivity/mosquitto/mosquitto/0001-set-restart-sec-to-prevent-systemd-prevent-the-servi.patch
@@ -1,0 +1,23 @@
+From 68a6c2133353f8b3603c8dfdd4e08432bc94e023 Mon Sep 17 00:00:00 2001
+From: Reuben Miller <reuben.d.miller@gmail.com>
+Date: Tue, 19 Nov 2024 22:27:47 +0100
+Subject: [PATCH] set restart sec to bypass systemd preventing the service
+ from starting due to failing on boot due to the listener ip addresses
+ not being available
+
+---
+ service/systemd/mosquitto.service.notify | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/service/systemd/mosquitto.service.notify b/service/systemd/mosquitto.service.notify
+index 06772dd..fd18692 100644
+--- a/service/systemd/mosquitto.service.notify
++++ b/service/systemd/mosquitto.service.notify
+@@ -10,6 +10,7 @@ NotifyAccess=main
+ ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
++RestartSec=5
+ ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
+ ExecStartPre=/bin/chown mosquitto:mosquitto /var/log/mosquitto
+ ExecStartPre=/bin/mkdir -m 740 -p /run/mosquitto

--- a/meta-tedge-common/recipes-connectivity/mosquitto/mosquitto_%.bbappend
+++ b/meta-tedge-common/recipes-connectivity/mosquitto/mosquitto_%.bbappend
@@ -1,5 +1,9 @@
 inherit useradd
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-set-restart-sec-to-prevent-systemd-prevent-the-servi.patch"
+
 # Used fix uid/gid to avoid permission problems on /data
 GROUPADD_PARAM:${PN} = "--system --gid 960 mosquitto"
 USERADD_PARAM:${PN} = "--system --no-create-home --shell /bin/false --uid 961 --gid 960 mosquitto"


### PR DESCRIPTION
When using a listener with an explicit bind address (or adapter), on boot mosquitto can fail repeatedly in quick succession which then activates systemd's service failure logic which then disables the service.

The mosquitto service now sets the `RestartSec` to 5 seconds, which prevents the systemd's mechanism from kicking in.