### PR TITLE
feat: move kas project definitions to meta-tedge repository

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,74 @@
+name: build
+
+on:
+  push:
+    branches:
+      - kirkstone
+  workflow_dispatch:
+  pull_request:
+    types: [ labeled ]
+
+env:
+  SSTATE_DIR: /data/yocto/sstate-cache
+  DL_DIR: /data/yocto/downloads
+
+jobs:
+  build:
+    if: github.event_name != 'pull_request' || github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci')
+    name: Build ${{ matrix.project }} ${{ matrix.machine }}
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - offsite_yocto
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - tedge-rauc
+          - tedge-mender
+        machine:
+          - raspberrypi3-64
+          - raspberrypi4-64
+        include:
+          - project: tedge-rauc
+            image_name: core-image-tedge-rauc
+            image_ext: "wic.bz2"
+            update_ext: "raucb"
+            manifest_ext: "manifest"
+
+          - project: tedge-mender
+            image_name: core-image-tedge-mender
+            image_ext: "sdimg.bz2"
+            update_ext: "mender"
+            manifest_ext: "manifest"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Only install tooling if not running on a self-hosted runner as the tools are already pre-installed
+      - uses: taiki-e/install-action@just
+        if: ${{ !startsWith(runner.name, 'tedge') }}
+      - uses: actions/setup-python@v5
+        if: ${{ !startsWith(runner.name, 'tedge') }}
+        with:
+          python-version: '3.8'
+      - run: pip3 install kas
+        if: ${{ !startsWith(runner.name, 'tedge') }}
+
+      - name: Build
+        run: just build-project projects/${{ matrix.project }}.yaml
+        working-directory: kas
+        env:
+          KAS_MACHINE: ${{ matrix.machine }}
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+            name: ${{ matrix.image_name }}_${{ matrix.machine }}
+            path: |
+              kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}_*.${{ matrix.image_ext }}
+              kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}_*.${{ matrix.update_ext }}
+              kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}_*.${{ matrix.manifest_ext }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+kas/_kas/
+kas/build/
+.env

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This meta layer contains all the recipes needed to build [thin-edge.io](https://
 
 ## How to start
 
-Check out the [meta-tedge-project](https://github.com/thin-edge/meta-tedge-project) for some example projects which make use of the thin-edge.io layer to create an image which includes Over-the-Air update support. The projects use [kas](https://github.com/siemens/kas) to make it easy to setup your yocto environment (e.g. checkout all of the required layers) and build your image in a single commands.
+Check out the [kas folder and README](./kas/README.md) for some example projects which make use of the thin-edge.io layer to create an image which includes Over-the-Air update support. The projects use [kas](https://github.com/siemens/kas) to make it easy to setup your Yocto environment (e.g. checkout all of the required layers) and build your image in a single commands.
 
 For more user-friendly documentation, check out the [official thin-edge.io documentation](https://thin-edge.github.io/thin-edge.io/extend/firmware-management/building-image/yocto/).
 
@@ -14,8 +14,8 @@ The repository follows the release-named branch strategy. Only LTS releases are 
 
 | Yocto Release | thin-edge version | Branch Name | Branch Status |
 | :- | :- | :- | :- |
-| Scarthgap | 1.0.1 | scarthgap | Active and maintained |
-| Kirkstone | 1.1.1 | kirkstone | Active and maintained |
+| Kirkstone | 1.x | kirkstone | Active and maintained |
+| Scarthgap | 1.x | scarthgap | In development (soon to be supported) |
 
 ## Dependencies
 

--- a/kas/README.md
+++ b/kas/README.md
@@ -1,0 +1,154 @@
+## Getting started
+
+This project shows how to build custom Yocto images which can be deployed to devices.
+
+Whilst the project can be modified to support your own setup, currently the project only includes the configuration required to deploy to the following devices:
+
+* Raspberry Pi 3 and 4 (64 bit variants only)
+
+
+### General project flow
+
+Below describes the general workflow when using this project to build an image and to deploy the image to a device.
+
+The project flow is as follows:
+
+```mermaid
+stateDiagram-v2
+    [*] --> BuildBootImage
+    BuildBootImage --> FlashBootImage
+    FlashBootImage --> OnboardDevice
+    OnboardDevice --> EditImage
+    EditImage --> BuildImage
+    BuildImage --> DeployImage
+    DeployImage --> EditImage: next version
+```
+
+Where each step is described below:
+
+|Step|Description|
+-----|-----------|
+|BuildBootImage|Build bootstrap image|
+|FlashBootImage|Flash the bootstrap image to the device, e.g. flash the SD card (this is only required once!)|
+|OnboardDevice|Register the device once to the cloud so you can enable Over-the-Air (OTA) updates|
+|EditImage|Modify your image when new future requirements come up|
+|BuildImage|Build a new image which includes the new changes|
+|DeployImage|Deploy the image to the device using OTA update|
+
+
+## Using the project
+
+### Prelude
+
+It is highly recommended to use **Ubuntu 20.04 LTS** for your build (host) machine. If you know what you are doing then you can use another linux distribution, however we cannot help you when things go wrong.
+
+#### Minimum requirements
+
+* At least 100 GB free disk space (however ~500GB is recommended as you don't want to run out and have to set all of this up again)
+* x86_64 Machine (arm64/aarch64 is not supported by Yocto)
+* Lots of time (first build can take > 6 hours...welcome to the world of yocto)
+
+
+### Installing the prerequisites
+
+To start off, you will need to install the project and Yocto dependencies.
+
+1. Clone the project and open a console at project's root directory
+
+2. Install just (follow the instructions on the [justfile website](https://just.systems/man/en/chapter_5.html))
+
+3. Install [kas](https://kas.readthedocs.io/en/latest/) (a tool used to managed yocto bitbake projects)
+
+    ```sh
+    pip3 install kas
+    ```
+
+4. Install the yocto dependencies
+
+    **Ubuntu 20.04 LTS**
+
+    ```sh
+    sudo apt install file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev xterm python3-subunit mesa-common-dev zstd liblz4-tool
+    ```
+
+    If you having troubles please consult the [Yocto Documentation](https://docs.yoctoproject.org/kirkstone/brief-yoctoprojectqs/index.html#building-your-image)
+
+**Reducing build times**
+
+You can configure a common **sstate cache** and download folder to share amongst different projects to speed up the build times.
+
+Create the following folders at the desired location, and then add the paths to the local `.env` file located at the root folder of the project (this file is not included in the project).
+
+*file: .env*
+
+```sh
+SSTATE_DIR=/data/yocto/sstate-cache
+DL_DIR=/data/yocto/downloads
+```
+
+### Building an image
+
+Build an image which includes thin-edge.io and [RAUC](https://rauc.readthedocs.io/en/latest/):
+
+**Raspberry Pi**
+
+```sh
+KAS_MACHINE=raspberrypi3-64 just build-project ./projects/tedge-rauc.yaml
+KAS_MACHINE=raspberrypi4-64 just build-project ./projects/tedge-rauc.yaml
+```
+
+Or you can save the KAS_MACHINE value in your .env file
+
+```
+KAS_MACHINE=raspberrypi3-64
+```
+
+The bootstrap image (which you can flash to an SD card) is located below:
+
+```sh
+ls -ltr "build/tmp/deploy/images/$KAS_MACHINE"/*.bz2
+```
+
+Where KAS_MACHINE should be replaced with the target machine value, e.g. `raspberrypi4-64`.
+
+### Publishing the OTA image file to Cumulocity IoT
+
+
+Publish/upload the built image to Cumulocity IoT (requires [go-c8y-cli](https://goc8ycli.netlify.app/) to be installed and a session to be active)
+
+```sh
+set-session "your_session"
+just publish
+```
+
+## Development Tasks
+
+### Updating yocto layers
+
+The projects use lock files in order to create reproducible builds by fixing layers to specific commits. Therefore if you need to update them, then run the following task:
+
+```sh
+just update-all-locks
+```
+
+Or you can specify which project file should be updated instead (if you want more control over it).
+
+```sh
+just update-lock ./projects/tedge-rauc.yaml
+```
+
+## Tips
+
+### Unexpected build errors
+
+If you run into unexpected build errors, or the image just doesn't include the expected contents, then try running the following task, then build again.
+
+```sh
+just clean
+```
+
+Or if you are still having problems, try removing all of the temp folders (build and the repositories)
+
+```sh
+just clean-all
+```

--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+bblayers_conf_header:
+  meta-common: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+
+local_conf_header:
+  meta-common: |
+    PACKAGE_CLASSES ?= "package_deb"
+    VOLATILE_LOG_DIR = "no"
+    IMAGE_INSTALL:append = " gnupg"
+    EXTRA_IMAGE_FEATURES ?= "debug-tweaks ssh-server-dropbear"
+    INIT_MANAGER="systemd"
+    TEDGE_CONFIG_DIR = "/etc/tedge"
+
+    # Add /etc/build file with information about build
+    INHERIT += "image-buildinfo"
+    IMAGE_BUILDINFO_VARS:append = " DATETIME DISTRO_NAME IMAGE_BASENAME IMAGE_NAME IMAGE_NAME_SUFFIX MACHINE TUNE_PKGARCH" 
+    IMAGE_BUILDINFO_VARS:append = " MACHINE_FEATURES DISTRO_FEATURES COMMON_FEATURES IMAGE_FEATURES"
+    IMAGE_BUILDINFO_VARS:append = " TUNE_FEATURES TARGET_FPU"
+
+    # Don't enable service by default as they will need to be bootstrapped first, though
+    # this may change in the future. But bootstrapping works anyway if the services are already enabled
+    # but they do consume more resources until it is bootstrapped
+    SYSTEMD_AUTO_ENABLE:tedge-agent = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-c8y = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-aws = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-az = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-collectd = "disable"

--- a/kas/config/mender-qemu.yaml
+++ b/kas/config/mender-qemu.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  meta-mender-qemu: |
+    INHERIT += "mender-full"
+    MENDER_ARTIFACT_NAME ?= "release-1"
+    SYSTEMD_AUTO_ENABLE:pn-mender-client = "disable"
+    IMAGE_FSTYPES:remove = " rpi-sdimg"
+    SDIMG_ROOTFS_TYPE = "ext4"
+    MENDER_BOOT_PART_SIZE_MB = "64"

--- a/kas/config/mender-raspberrypi.yaml
+++ b/kas/config/mender-raspberrypi.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  meta-mender-raspberrypi: |
+    INHERIT += "mender-full"
+    MENDER_ARTIFACT_NAME ?= "release-1"
+    SYSTEMD_AUTO_ENABLE:pn-mender-client = "disable"
+    RPI_USE_U_BOOT = "1"
+    IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
+    IMAGE_FSTYPES:remove = " rpi-sdimg"
+    SDIMG_ROOTFS_TYPE = "ext4"
+
+    MENDER_STORAGE_TOTAL_SIZE_MB ?= "2048"
+    MENDER_BOOT_PART_SIZE_MB ?= "64"
+    MENDER_DATA_PART_SIZE_MB ?= "512"
+
+    # mender golang client 3.x
+    #PREFERRED_PROVIDER_mender-native = "mender-client-native"
+    #PREFERRED_RPROVIDER_mender-auth = "mender-client"
+    #PREFERRED_RPROVIDER_mender-update = "mender-client"
+
+    # mender cpp client >=4.x
+    PREFERRED_PROVIDER_mender-native = "mender-native"
+    PREFERRED_RPROVIDER_mender-auth = "mender"
+    PREFERRED_RPROVIDER_mender-update = "mender"

--- a/kas/config/package-management.yaml
+++ b/kas/config/package-management.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  meta-package-management: |
+    PACKAGE_CLASSES = "package_deb"
+    IMAGE_FEATURES:append = " package-management"

--- a/kas/config/raspberrypi.yaml
+++ b/kas/config/raspberrypi.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 1
+
+local_conf_header:
+  meta-raspberrypi: |
+    DISTRO_FEATURES:append = " bluez5 bluetooth wifi "
+    IMAGE_INSTALL:append = " linux-firmware-rpidistro-bcm43430 bluez5 i2c-tools"
+    ENABLE_UART = "1"

--- a/kas/config/rauc-raspberrypi.yaml
+++ b/kas/config/rauc-raspberrypi.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  rauc-raspberrypi: |
+    RPI_USE_U_BOOT = "1"
+    IMAGE_INSTALL:append = " rauc rauc-grow-data-part"
+    DISTRO_FEATURES:append = " rauc"
+    IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
+    PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
+    IMAGE_FSTYPES = " tar.bz2 ext4 wic.bz2 wic.bmap"
+    SDIMG_ROOTFS_TYPE = "ext4"
+    # Note: Image must be a multiple of 4096 for adaptive updates to work!
+    IMAGE_ROOTFS_EXTRA_SPACE:append = " + 409600"
+    WKS_FILE = "sdimage-dual-raspberrypi.wks.in"

--- a/kas/config/read-only-with-overlay.yaml
+++ b/kas/config/read-only-with-overlay.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  meta-read-only: |
+    IMAGE_FEATURES:append = " read-only-rootfs overlayfs-etc"
+    IMAGE_FEATURES:remove = " package-management"
+
+    OVERLAYFS_ETC_MOUNT_POINT ?= "/mnt/etc"
+    OVERLAYFS_ETC_FSTYPE ?= "ext4"
+    OVERLAYFS_ETC_DEVICE ?= "/dev/mmcblk0p5"

--- a/kas/config/read-only.yaml
+++ b/kas/config/read-only.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  meta-read-only: |
+    IMAGE_FEATURES:append = " read-only-rootfs"
+    IMAGE_FEATURES:remove = " package-management"
+
+    # Note: /data/tedge will be created when the image is used as /data does not exist at build time
+    TEDGE_CONFIG_DIR = "/etc/tedge-default"
+    TEDGE_CONFIG_SYMLINK = "/etc/tedge"
+    TEDGE_CONFIG_SYMLINK_SRC = "/data/tedge"
+
+    # Enable services by default as services can't be enabled at runtime with a read-only rootfs
+    SYSTEMD_AUTO_ENABLE:tedge-agent = "enable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-c8y = "enable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-aws = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-az = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-collectd = "disable"
+
+    # `has_journal` interferes with the checksum of the image when viewed from the block device. Oddly
+    # enough it is not present on disk, IOW, when the image is mounted readonly, the physical checksum
+    # on disk, and the checksum of the corresponding block device, are not the same. Work around this by
+    # disabling the journal for read-only filesystems, where it is useless anyway.
+    EXTRA_IMAGECMD:ext4:append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^has_journal', '', d)}"

--- a/kas/config/swupdate.yaml
+++ b/kas/config/swupdate.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  meta-swupdate: |
+    IMAGE_FSTYPES += "ext4.gz"
+    RPI_USE_U_BOOT = "1"

--- a/kas/config/tedge-docker.yaml
+++ b/kas/config/tedge-docker.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  meta-tedge-container-plugin: |
+    DISTRO_FEATURES:append = " virtualization"
+    IMAGE_INSTALL:append = " docker-ce"
+    IMAGE_INSTALL:append = " docker-compose"
+    IMAGE_INSTALL:append = " tedge-container-plugin"

--- a/kas/justfile
+++ b/kas/justfile
@@ -33,7 +33,7 @@ clean-all:
 # You need to run this if you are working on a branch and would like up-to-date
 # changes
 update-lock file *args="": init
-    python3 -m kas dump --update --lock {{args}} {{file}} --inplace
+    python3 -m kas dump --update --indent 2 --lock {{args}} {{file}} --inplace
 
 # Build project from a given file
 build-project file *args="": init

--- a/kas/justfile
+++ b/kas/justfile
@@ -1,0 +1,55 @@
+set dotenv-load
+
+# Use custom work_dir for kas, so the folder can be added to the gitignore list
+# but keep the build dir under <project>/build
+export KAS_WORK_DIR := env_var_or_default("KAS_WORK_DIR", justfile_directory() + "/_kas")
+export KAS_BUILD_DIR := env_var_or_default("KAS_BUILD_DIR", justfile_directory() + "/build")
+
+# Use an auto generated image version suffix (based on date) if one is not provided
+export IMAGE_VERSION := env_var_or_default("IMAGE_VERSION", "" + `date +%Y%m%d.%H%M`)
+export IMAGE_VERSION_SUFFIX := "_" + IMAGE_VERSION
+
+# Init build folders
+init:
+    mkdir -p "{{KAS_WORK_DIR}}"
+    mkdir -p "{{KAS_BUILD_DIR}}"
+
+# Generate a build version
+generate-version:
+    @echo "{{IMAGE_VERSION_SUFFIX}}"
+
+# Clean temp build folder
+clean:
+    @echo "Cleaning tmp folder"
+    rm -rf build/tmp
+
+# Clean all build and yocto folders
+clean-all:
+    @echo "Cleaning all local yocto folders"
+    rm -rf build
+    rm -rf _kas
+
+# Update project lock file to lock to specific commit per layer
+# You need to run this if you are working on a branch and would like up-to-date
+# changes
+update-lock file *args="": init
+    python3 -m kas dump --update --lock {{args}} {{file}} --inplace
+
+# Build project from a given file
+build-project file *args="": init
+    python3 -m kas build {{file}} {{args}}
+
+# Run custom bitbake command with a given project
+bitbake file *args="": init
+    python3 -m kas shell {{file}} -c 'bitbake {{args}}'
+
+# Publish image to Cumulocity IoT (requires go-c8y-cli to be installed)
+publish *args="":
+    {{justfile_directory()}}/scripts/publish-c8y.sh {{args}}
+
+runqemu config="./projects/tedge-rauc.yaml":
+    kas shell {{config}} -c 'runqemu'
+
+# Update the lock files of all projects
+update-all-locks:
+    find ./projects -maxdepth 1 \( -name "*.yaml" -a ! -name "*.lock.*" \) -exec just update-lock {} \;

--- a/kas/projects/tedge-bin-rauc.lock.yaml
+++ b/kas/projects/tedge-bin-rauc.lock.yaml
@@ -1,0 +1,18 @@
+header:
+  version: 14
+overrides:
+  repos:
+    meta-lts-mixins-go:
+      commit: 7b4c22b4114c5789a6cb7d8b0b7c7078cd9f0dc9
+    meta-openembedded:
+      commit: 4ad41baed6236d499804cbfc4f174042d84fce97
+    meta-raspberrypi:
+      commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
+    meta-rauc:
+      commit: b27b59e2f9a3a7446f740b10560462076ef07009
+    meta-rauc-community:
+      commit: fdaccecf6f950ccc21628aa2d8a5d7f9557eaabc
+    meta-virtualization:
+      commit: c996df33763f292da5e7513c574272d7de23eafc
+    poky:
+      commit: 8e092852b63e998d990b8f8e1aa91297dec4430f

--- a/kas/projects/tedge-bin-rauc.yaml
+++ b/kas/projects/tedge-bin-rauc.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+  includes:
+    - ../config/common.yaml
+    - ../config/raspberrypi.yaml
+    - ../config/rauc-raspberrypi.yaml
+    - ../config/package-management.yaml
+    - ../config/tedge-docker.yaml
+
+machine: raspberrypi4-64
+distro: poky
+target: rauc-update-bundle
+
+env:
+  IMAGE_VERSION: ""
+  IMAGE_VERSION_SUFFIX: "_123123"
+  BUNDLE_NAME: "core-image-tedge-rauc-${MACHINE}${IMAGE_VERSION_SUFFIX}"
+  RAUC_BUNDLE_VERSION: "${IMAGE_VERSION}"
+
+defaults:
+  repos:
+    branch: kirkstone
+
+repos:
+  poky:
+    url: "https://git.yoctoproject.org/git/poky"
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-raspberrypi:
+    url: "https://github.com/agherzan/meta-raspberrypi.git"
+
+  meta-openembedded:
+    url: "https://git.openembedded.org/meta-openembedded"
+    layers:
+      meta-oe:
+      meta-python:
+      meta-networking:
+      meta-multimedia:
+      meta-filesystems:
+
+  meta-rauc:
+    url: "https://github.com/rauc/meta-rauc.git"
+
+  meta-rauc-community:
+    url: "https://github.com/thin-edge/meta-rauc-community"
+    branch: kirkstone-fork
+    layers:
+      meta-rauc-raspberrypi:
+
+  meta-tedge:
+    path: ../../
+    layers:
+      meta-tedge-bin:
+      meta-tedge-common:
+      meta-tedge-rauc:
+      meta-tedge-extras:
+      meta-raspberrypi:
+
+  meta-lts-mixins-go:
+    url: "https://github.com/moto-timo/meta-lts-mixins.git"
+    branch: kirkstone/go
+
+  meta-virtualization:
+    url: "https://git.yoctoproject.org/meta-virtualization"

--- a/kas/projects/tedge-mender-qemu.lock.yaml
+++ b/kas/projects/tedge-mender-qemu.lock.yaml
@@ -1,0 +1,16 @@
+header:
+  version: 14
+overrides:
+  repos:
+    meta-lts-mixins-go:
+      commit: 7b4c22b4114c5789a6cb7d8b0b7c7078cd9f0dc9
+    meta-mender:
+      commit: 9efa9409684e303472ed9dae749ab663909eb689
+    meta-openembedded:
+      commit: 4ad41baed6236d499804cbfc4f174042d84fce97
+    meta-rust:
+      commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
+    meta-virtualization:
+      commit: c996df33763f292da5e7513c574272d7de23eafc
+    poky:
+      commit: 8e092852b63e998d990b8f8e1aa91297dec4430f

--- a/kas/projects/tedge-mender-qemu.yaml
+++ b/kas/projects/tedge-mender-qemu.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+  includes:
+    - ../config/common.yaml
+    - ../config/mender-qemu.yaml
+    - ../config/package-management.yaml
+    - ../config/tedge-docker.yaml
+
+machine: qemux86-64
+distro: poky
+target: core-image-tedge-mender
+
+env:
+  IMAGE_VERSION_SUFFIX: "_123123"
+  MENDER_ARTIFACT_NAME: "core-image-tedge-mender-${MACHINE}${IMAGE_VERSION_SUFFIX}"
+
+defaults:
+  repos:
+    branch: kirkstone
+
+repos:
+  poky:
+    url: "https://git.yoctoproject.org/git/poky"
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: "https://git.openembedded.org/meta-openembedded"
+    layers:
+      meta-oe:
+      meta-python:
+      meta-networking:
+      meta-multimedia:
+      meta-filesystems:
+
+  meta-mender:
+    url: "https://github.com/mendersoftware/meta-mender"
+    layers:
+      meta-mender-core:
+      meta-mender-qemu:
+
+  meta-rust:
+    url: "https://github.com/meta-rust/meta-rust"
+    branch: master
+
+  meta-tedge:
+    path: ../../
+    layers:
+      meta-tedge:
+      meta-tedge-common:
+      meta-tedge-mender:
+      meta-tedge-extras:
+
+  meta-lts-mixins-go:
+    url: "https://github.com/moto-timo/meta-lts-mixins.git"
+    branch: kirkstone/go
+
+  meta-virtualization:
+    url: "https://git.yoctoproject.org/meta-virtualization"

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -1,0 +1,18 @@
+header:
+  version: 14
+overrides:
+  repos:
+    meta-lts-mixins-go:
+      commit: 7b4c22b4114c5789a6cb7d8b0b7c7078cd9f0dc9
+    meta-mender:
+      commit: 9efa9409684e303472ed9dae749ab663909eb689
+    meta-openembedded:
+      commit: 4ad41baed6236d499804cbfc4f174042d84fce97
+    meta-raspberrypi:
+      commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
+    meta-rust:
+      commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
+    meta-virtualization:
+      commit: c996df33763f292da5e7513c574272d7de23eafc
+    poky:
+      commit: 8e092852b63e998d990b8f8e1aa91297dec4430f

--- a/kas/projects/tedge-mender.yaml
+++ b/kas/projects/tedge-mender.yaml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+  includes:
+    - ../config/common.yaml
+    - ../config/raspberrypi.yaml
+    - ../config/mender-raspberrypi.yaml
+    - ../config/package-management.yaml
+    - ../config/tedge-docker.yaml
+
+machine: raspberrypi4-64
+distro: poky
+target: core-image-tedge-mender
+
+env:
+  IMAGE_VERSION_SUFFIX: "_123123"
+  MENDER_ARTIFACT_NAME: "core-image-tedge-mender-${MACHINE}${IMAGE_VERSION_SUFFIX}"
+
+defaults:
+  repos:
+    branch: kirkstone
+
+repos:
+  poky:
+    url: "https://git.yoctoproject.org/git/poky"
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-raspberrypi:
+    url: "https://github.com/agherzan/meta-raspberrypi.git"
+
+  meta-openembedded:
+    url: "https://git.openembedded.org/meta-openembedded"
+    layers:
+      meta-oe:
+      meta-python:
+      meta-networking:
+      meta-multimedia:
+      meta-filesystems:
+
+  meta-mender:
+    url: "https://github.com/mendersoftware/meta-mender"
+    layers:
+      meta-mender-core:
+      meta-mender-raspberrypi:
+
+  meta-rust:
+    url: "https://github.com/meta-rust/meta-rust"
+    branch: master
+
+  meta-tedge:
+    path: ../../
+    layers:
+      meta-tedge:
+      meta-tedge-common:
+      meta-tedge-mender:
+      meta-tedge-extras:
+      meta-raspberrypi:
+
+  meta-lts-mixins-go:
+    url: "https://github.com/moto-timo/meta-lts-mixins.git"
+    branch: kirkstone/go
+  
+  meta-virtualization:
+    url: "https://git.yoctoproject.org/meta-virtualization"

--- a/kas/projects/tedge-rauc.lock.yaml
+++ b/kas/projects/tedge-rauc.lock.yaml
@@ -1,0 +1,20 @@
+header:
+  version: 14
+overrides:
+  repos:
+    meta-lts-mixins-go:
+      commit: 7b4c22b4114c5789a6cb7d8b0b7c7078cd9f0dc9
+    meta-openembedded:
+      commit: 4ad41baed6236d499804cbfc4f174042d84fce97
+    meta-raspberrypi:
+      commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
+    meta-rauc:
+      commit: b27b59e2f9a3a7446f740b10560462076ef07009
+    meta-rauc-community:
+      commit: fdaccecf6f950ccc21628aa2d8a5d7f9557eaabc
+    meta-rust:
+      commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
+    meta-virtualization:
+      commit: c996df33763f292da5e7513c574272d7de23eafc
+    poky:
+      commit: 8e092852b63e998d990b8f8e1aa91297dec4430f

--- a/kas/projects/tedge-rauc.yaml
+++ b/kas/projects/tedge-rauc.yaml
@@ -1,0 +1,72 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+  includes:
+    - ../config/common.yaml
+    - ../config/raspberrypi.yaml
+    - ../config/rauc-raspberrypi.yaml
+    - ../config/package-management.yaml
+    - ../config/tedge-docker.yaml
+
+machine: raspberrypi4-64
+distro: poky
+target: rauc-update-bundle
+
+env:
+  IMAGE_VERSION: ""
+  IMAGE_VERSION_SUFFIX: "_123123"
+  BUNDLE_NAME: "core-image-tedge-rauc-${MACHINE}${IMAGE_VERSION_SUFFIX}"
+  RAUC_BUNDLE_VERSION: "${IMAGE_VERSION}"
+
+defaults:
+  repos:
+    branch: kirkstone
+
+repos:
+  poky:
+    url: "https://git.yoctoproject.org/git/poky"
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-raspberrypi:
+    url: "https://github.com/agherzan/meta-raspberrypi.git"
+
+  meta-openembedded:
+    url: "https://git.openembedded.org/meta-openembedded"
+    layers:
+      meta-oe:
+      meta-python:
+      meta-networking:
+      meta-multimedia:
+      meta-filesystems:
+
+  meta-rauc:
+    url: "https://github.com/rauc/meta-rauc.git"
+
+  meta-rauc-community:
+    url: "https://github.com/thin-edge/meta-rauc-community"
+    branch: kirkstone-fork
+    layers:
+      meta-rauc-raspberrypi:
+
+  meta-rust:
+    url: "https://github.com/meta-rust/meta-rust"
+    branch: master
+
+  meta-tedge:
+    path: ../../
+    layers:
+      meta-tedge:
+      meta-tedge-common:
+      meta-tedge-rauc:
+      meta-tedge-extras:
+      meta-raspberrypi:
+
+  meta-lts-mixins-go:
+    url: "https://github.com/moto-timo/meta-lts-mixins.git"
+    branch: kirkstone/go
+
+  meta-virtualization:
+    url: "https://git.yoctoproject.org/meta-virtualization"

--- a/kas/scripts/publish-c8y.sh
+++ b/kas/scripts/publish-c8y.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+FILE_EXT=${FILE_EXT:-raucb}
+
+if [ $# -gt 0 ]; then
+    FILE_EXT="$1"
+    shift
+fi
+
+if ! command -V c8y >/dev/null 2>&1; then
+    echo "Missing dependency. Please install go-c8y-cli via https://goc8ycli.netlify.app/" >&2
+    exit 1
+fi
+
+if [ -n "$KAS_MACHINE" ]; then
+    MACHINE="$KAS_MACHINE"
+else
+    MACHINE="${MACHINE:-raspberrypi4-64}"
+fi
+
+SEARCH_DIR="build/tmp/deploy/images/$MACHINE"
+echo "Searching for *.$FILE_EXT files under $SEARCH_DIR" >&2
+FIRMWARE_FILE=$(find "$SEARCH_DIR" -name "*_*.$FILE_EXT" | tail -1)
+if [ -z "$FIRMWARE_FILE" ]; then
+    echo "Could not find the .$FILE_EXT image" >&2
+    exit 1
+fi
+
+FIRMWARE_NAME=$(basename "$FIRMWARE_FILE" | cut -d_ -f1)
+FIRMWARE_VERSION=$(basename "$FIRMWARE_FILE" | cut -d_ -f2 | sed 's/\.[a-zA-Z]*$//g')
+
+echo "Found firmware. name=$FIRMWARE_NAME, version=$FIRMWARE_VERSION, file=$FIRMWARE_FILE" >&2
+
+# Create software name (if it does not already exist)
+c8y firmware get -n --id "$FIRMWARE_NAME" --silentStatusCodes 404 >/dev/null \
+    || c8y firmware create -n --name "$FIRMWARE_NAME" --delay "1s" --force
+
+c8y firmware versions get -n --firmware "$FIRMWARE_NAME" --id "$FIRMWARE_VERSION" --silentStatusCodes 404 >/dev/null \
+    || c8y firmware versions create -n --file "$FIRMWARE_FILE" --firmware "$FIRMWARE_NAME" --version "$FIRMWARE_VERSION" --force "$@"

--- a/kas/template.env
+++ b/kas/template.env
@@ -1,0 +1,4 @@
+# SSTATE_DIR=/data/yocto/sstate-cache
+# DL_DIR=/data/yocto/downloads
+#IMAGE_VERSION_SUFFIX=
+#KAS_MACHINE=raspberrypi3-64


### PR DESCRIPTION
Move the from the [kas](https://kas.readthedocs.io/en/latest/) [meta-tedge-project](https://github.com/thin-edge/meta-tedge-project) project to the [meta-tedge](https://github.com/thin-edge/meta-tedge).

The main motivation for moving the kas project definition files to this repository is so that any layer changes can be more easily validated before being merged, and since the two repos are tightly coupled, it enables the repos to remain in sync without having to rely on the kas project lock files (which just makes validation of development more difficult as the developed would always have to change the layer url to point to a fork when doing any changes in the meta-tedge project).
