### PR TITLE
fix(c8y-command-plugin): fix source version

### DIFF
--- a/meta-tedge-common/recipes-tedge/c8y-command-plugin/c8y-command-plugin_git.bb
+++ b/meta-tedge-common/recipes-tedge/c8y-command-plugin/c8y-command-plugin_git.bb
@@ -1,5 +1,5 @@
 SRC_URI += "git://git@github.com/thin-edge/c8y-command-plugin.git;protocol=https;branch=main"
-SRCREV = "${AUTOREV}"
+SRCREV = "ef9a9e1d76c3a67ec56243658ce6a1b6b42799db"
 
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = " \


### PR DESCRIPTION
Prevent build breakage due to rework going on in the c8y-command-plugin to prepare for upcoming workflow version (which will require thin-edge.io 1.4.0)