### PR TITLE
fix(bootstrap): start docker on bootstrapping to prevent mosquitto listener error

### DIFF
--- a/meta-tedge-common/recipes-tedge/tedge-bootstrap/tedge-bootstrap/tedge-bootstrap
+++ b/meta-tedge-common/recipes-tedge/tedge-bootstrap/tedge-bootstrap/tedge-bootstrap
@@ -45,6 +45,23 @@ while [ "$attempt" -lt 30 ]; do
     sleep 5
 done
 
+if command -v docker >/dev/null 2>&1; then
+    # Start docker service
+    #
+    # Note:
+    # docker is not a socket activated service, meaning that it will
+    # not be started when the device starts. This causes a problem
+    # with the default mosquitto listener which is enabled specifically
+    # for the docker network (gateway) to enable access to the tedge MQTT
+    # broker from containers. As mosquitto starts, it fails to bind to
+    # the container gateway network as it does not yet exist, thus leading
+    # to continuous restarting of the mosquitto service, which makes it
+    # impossible to onboard the device.
+    #
+    log "Starting docker (by simply using it)"
+    docker ps || log "Warning: Failed to start docker, continuing anyway"
+fi
+
 init_tedge_data
 
 # Run bootstrapping hooks


### PR DESCRIPTION
docker is not a socket activated service, meaning that it will not be started when the device starts. This causes a problem with the default mosquitto listener which is enabled specifically for the docker network (gateway) to enable access to the tedge MQTT broker from containers.

As mosquitto starts, it fails to bind to the container gateway network as it does not yet exist, thus leading to continuous restarting of the mosquitto service, which makes it impossible to onboard the device.