### PR TITLE
refactor: move network manager and monit configuration to independent config

### DIFF
--- a/kas/config/monitor.yaml
+++ b/kas/config/monitor.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+bblayers_conf_header:
+  meta-common: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+
+local_conf_header:
+  meta-monitor: |
+    IMAGE_INSTALL += "monit"

--- a/kas/config/network.yaml
+++ b/kas/config/network.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+bblayers_conf_header:
+  meta-common: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+
+local_conf_header:
+  meta-network: |
+    IMAGE_INSTALL += "networkmanager networkmanager-bash-completion networkmanager-nmtui"

--- a/kas/projects/tedge-bin-rauc.yaml
+++ b/kas/projects/tedge-bin-rauc.yaml
@@ -5,6 +5,8 @@ header:
     - ../config/common.yaml
     - ../config/raspberrypi.yaml
     - ../config/rauc-raspberrypi.yaml
+    - ../config/network.yaml
+    - ../config/monitor.yaml
     - ../config/package-management.yaml
     - ../config/tedge-docker.yaml
     - ../config/tedge-nodered.yaml

--- a/kas/projects/tedge-mender-qemu.yaml
+++ b/kas/projects/tedge-mender-qemu.yaml
@@ -4,6 +4,8 @@ header:
   includes:
     - ../config/common.yaml
     - ../config/mender-qemu.yaml
+    - ../config/network.yaml
+    - ../config/monitor.yaml
     - ../config/package-management.yaml
     - ../config/tedge-docker.yaml
     - ../config/tedge-nodered.yaml

--- a/kas/projects/tedge-mender.yaml
+++ b/kas/projects/tedge-mender.yaml
@@ -5,6 +5,8 @@ header:
     - ../config/common.yaml
     - ../config/raspberrypi.yaml
     - ../config/mender-raspberrypi.yaml
+    - ../config/network.yaml
+    - ../config/monitor.yaml
     - ../config/package-management.yaml
     - ../config/tedge-docker.yaml
     - ../config/tedge-nodered.yaml

--- a/kas/projects/tedge-rauc.yaml
+++ b/kas/projects/tedge-rauc.yaml
@@ -5,6 +5,8 @@ header:
     - ../config/common.yaml
     - ../config/raspberrypi.yaml
     - ../config/rauc-raspberrypi.yaml
+    - ../config/network.yaml
+    - ../config/monitor.yaml
     - ../config/package-management.yaml
     - ../config/tedge-docker.yaml
     - ../config/tedge-nodered.yaml

--- a/meta-tedge-rauc/recipes-core/images/core-image-tedge-rauc.bb
+++ b/meta-tedge-rauc/recipes-core/images/core-image-tedge-rauc.bb
@@ -6,9 +6,6 @@ IMAGE_INSTALL:append = " \
     ${@bb.utils.contains('INIT_MANAGER','systemd','tedge-sethostname','',d)} \
 "
 
-# Add Network Manager
-IMAGE_INSTALL += "networkmanager networkmanager-bash-completion networkmanager-nmtui monit"
-
 # Optimizations for RAUC adaptive method 'block-hash-index'
 # rootfs image size must to be 4K-aligned
 # reference: https://github.com/rauc/meta-rauc-community/blob/master/meta-rauc-qemux86/recipes-core/images/core-image-minimal.bbappend


### PR DESCRIPTION
Remove the installation of networkmanager and monit from the tedge-rauc image as these packages are not strictly required so it lets users decide which networking tools they wish to use.

The networkmanager and monit tools are now instead included only in the kas projects (not the yocto image definitions).