### PR TITLE
ci: build images for all raspberry pi machines

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,8 +28,11 @@ jobs:
           - tedge-rauc
           - tedge-mender
         machine:
-          - raspberrypi3-64
-          - raspberrypi4-64
+          - raspberrypi
+          - raspberrypi2
+          # RaspberryPi 64 bit: 3b, 4, 5, zero2w, cm3, cm4, cm4s
+          # https://git.yoctoproject.org/meta-raspberrypi/tree/conf/machine/raspberrypi-armv8.conf?h=master
+          - raspberrypi-armv8
         include:
           - project: tedge-rauc
             image_name: core-image-tedge-rauc

--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -20,6 +20,7 @@ local_conf_header:
     IMAGE_BUILDINFO_VARS:append = " DATETIME DISTRO_NAME IMAGE_BASENAME IMAGE_NAME IMAGE_NAME_SUFFIX MACHINE TUNE_PKGARCH" 
     IMAGE_BUILDINFO_VARS:append = " MACHINE_FEATURES DISTRO_FEATURES COMMON_FEATURES IMAGE_FEATURES"
     IMAGE_BUILDINFO_VARS:append = " TUNE_FEATURES TARGET_FPU"
+    IMAGE_BUILDINFO_VARS:append = " DEVICE_MODEL"
 
     # Don't enable service by default as they will need to be bootstrapped first, though
     # this may change in the future. But bootstrapping works anyway if the services are already enabled

--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -11,7 +11,7 @@ local_conf_header:
     PACKAGE_CLASSES ?= "package_deb"
     VOLATILE_LOG_DIR = "no"
     IMAGE_INSTALL:append = " gnupg"
-    EXTRA_IMAGE_FEATURES ?= "debug-tweaks ssh-server-dropbear"
+    EXTRA_IMAGE_FEATURES:append = " debug-tweaks ssh-server-dropbear"
     INIT_MANAGER="systemd"
     TEDGE_CONFIG_DIR = "/etc/tedge"
 


### PR DESCRIPTION
Build images for all raspberry pi machines:

* use `raspberrypi-armv8` to support multiple machines, rpi 3b, 4, 5, cm3, cm4 etc.

    * raspberry - Raspberry Pi 1 (32 bit)
    * raspberry2 - Raspberry Pi 2 (32 bit)

Also add minor improvements:
* include DEVICE_MODEL variable in build info
* use `EXTRA_IMAGE_FEATURES:append` to ensure the extra packages are always added to the image which was not the case when an image definition included a `EXTRA_IMAGE_FEATURES` line.