### PR TITLE
feat(mender): remove wic image types as they are not supported by mender

### DIFF
--- a/kas/config/mender-qemu.yaml
+++ b/kas/config/mender-qemu.yaml
@@ -7,6 +7,6 @@ local_conf_header:
     INHERIT += "mender-full"
     MENDER_ARTIFACT_NAME ?= "release-1"
     SYSTEMD_AUTO_ENABLE:pn-mender-client = "disable"
-    IMAGE_FSTYPES:remove = " rpi-sdimg"
+    IMAGE_FSTYPES:remove = " rpi-sdimg wic.bz2 wic.bmap"
     SDIMG_ROOTFS_TYPE = "ext4"
     MENDER_BOOT_PART_SIZE_MB = "64"

--- a/kas/config/mender-raspberrypi.yaml
+++ b/kas/config/mender-raspberrypi.yaml
@@ -9,7 +9,7 @@ local_conf_header:
     SYSTEMD_AUTO_ENABLE:pn-mender-client = "disable"
     RPI_USE_U_BOOT = "1"
     IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
-    IMAGE_FSTYPES:remove = " rpi-sdimg"
+    IMAGE_FSTYPES:remove = " rpi-sdimg wic.bz2 wic.bmap"
     SDIMG_ROOTFS_TYPE = "ext4"
 
     MENDER_STORAGE_TOTAL_SIZE_MB ?= "2048"


### PR DESCRIPTION
Removing unused wic image types for mender images as they don't function, so by not building them it avoids the users from accidentally using it.