### PR TITLE
fix(bootstrap): sort bootstrap script hooks before executing

### DIFF
--- a/meta-tedge-common/recipes-tedge/tedge-bootstrap/tedge-bootstrap/tedge-bootstrap
+++ b/meta-tedge-common/recipes-tedge/tedge-bootstrap/tedge-bootstrap/tedge-bootstrap
@@ -54,11 +54,11 @@ NAME_FILTER="[0-9][0-9]_*"
 _NEWLINE=$(printf '\n')
 find -L "$RUN_PARTS" -type f -name "$NAME_FILTER" -perm 755 | sort -V | while IFS="$_NEWLINE" read -r file
 do
-    echo "Executing bootstrap script: $file" >&2
+    log "Executing bootstrap script: $file"
     if "$file" "$DEVICE_ID"; then
         log "bootstrap hook ($file) was successful"
     else
-        log "boostrap hook ($file) failed. Exiting..."
+        log "bootstrap hook ($file) failed. Exiting..."
         exit 1
     fi
 done

--- a/meta-tedge-common/recipes-tedge/tedge-bootstrap/tedge-bootstrap/tedge-bootstrap
+++ b/meta-tedge-common/recipes-tedge/tedge-bootstrap/tedge-bootstrap/tedge-bootstrap
@@ -52,7 +52,7 @@ RUN_PARTS="/usr/share/tedge-bootstrap/scripts.d"
 NAME_FILTER="[0-9][0-9]_*"
 
 _NEWLINE=$(printf '\n')
-find -L "$RUN_PARTS" -type f -name "$NAME_FILTER" -perm 755 | while IFS="$_NEWLINE" read -r file
+find -L "$RUN_PARTS" -type f -name "$NAME_FILTER" -perm 755 | sort -V | while IFS="$_NEWLINE" read -r file
 do
     echo "Executing bootstrap script: $file" >&2
     if "$file" "$DEVICE_ID"; then


### PR DESCRIPTION
Ensure the bootstrap scripts are sorted before they are executed so that users can control the sequence of execution, by using the `XX_` prefix. 

For example, given the following bootstrap scripts:

* 50_do_something
* 01_early_init
* 60_another-bootstrap

Will be executed in the following order (as they are sorted alphabetically)

1. 01_early_init
2. 50_do_something
3. 60_another-bootstrap
