### PR TITLE
chore: project cleanup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,11 +67,17 @@ jobs:
         working-directory: kas
         env:
           KAS_MACHINE: ${{ matrix.machine }}
+
+      # Delete any symlinks as this affects the artifact upload pattern
+      - name: Delete image symlinks
+        run: |
+          find "kas/build/tmp/deploy/images/${{ matrix.machine }}/" -type l -name "${{ matrix.image_name }}*" -delete
+
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-            name: ${{ matrix.image_name }}_${{ matrix.machine }}
-            path: |
-              kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}_*.${{ matrix.image_ext }}
-              kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}_*.${{ matrix.update_ext }}
-              kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}_*.${{ matrix.manifest_ext }}
+          name: ${{ matrix.image_name }}_${{ matrix.machine }}
+          path: |
+            kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}*.${{ matrix.image_ext }}
+            kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}*.${{ matrix.update_ext }}
+            kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}*.${{ matrix.manifest_ext }}

--- a/meta-raspberrypi/conf/layer.conf
+++ b/meta-raspberrypi/conf/layer.conf
@@ -5,13 +5,6 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-# Add layer-specific recipes
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bb' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-             
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-
 BBFILE_COLLECTIONS += "recipes-kernel"
 BBFILE_PATTERN_recipes-kernel = "^${LAYERDIR}/"
 BBFILE_PRIORITY_recipes-kernel = "6"

--- a/meta-tedge-bin/conf/layer.conf
+++ b/meta-tedge-bin/conf/layer.conf
@@ -5,13 +5,6 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-# Add layer-specific recipes
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bb' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-             
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-
 BBFILE_COLLECTIONS += "meta-tedge-bin"
 BBFILE_PATTERN_meta-tedge-bin = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tedge-bin = "6"

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
@@ -9,7 +9,6 @@ SRC_URI += " \
 
 RDEPENDS:${PN} += " mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo collectd"
 
-inherit logging
 inherit bin_package useradd
 
 INSANE_SKIP:${PN} = "already-stripped"

--- a/meta-tedge-common/conf/layer.conf
+++ b/meta-tedge-common/conf/layer.conf
@@ -5,13 +5,6 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-# add recipes for subprojects
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bb' % layer \
-	for layer in BBFILE_COLLECTIONS.split())}"
-             
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
-	for layer in BBFILE_COLLECTIONS.split())}"
-
 BBFILE_COLLECTIONS += "meta-tedge-common"
 BBFILE_PATTERN_meta-tedge-common = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tedge-common = "6"

--- a/meta-tedge-extras/conf/layer.conf
+++ b/meta-tedge-extras/conf/layer.conf
@@ -5,13 +5,6 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-# Add layer-specific recipes
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bb' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-             
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-
 BBFILE_COLLECTIONS += "meta-tedge-extras"
 BBFILE_PATTERN_meta-tedge-extras = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tedge-extras = "6"

--- a/meta-tedge-mender/conf/layer.conf
+++ b/meta-tedge-mender/conf/layer.conf
@@ -5,13 +5,6 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-# Add layer-specific recipes
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bb' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-             
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-
 BBFILE_COLLECTIONS += "meta-tedge-mender"
 BBFILE_PATTERN_meta-tedge-mender = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tedge-mender = "6"

--- a/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware.bb
+++ b/meta-tedge-mender/recipes-tedge/tedge-firmware/tedge-firmware.bb
@@ -8,7 +8,6 @@ SRC_URI += " \
     file://persist.conf \
 "
 
-inherit logging
 inherit allarch
 
 DEPENDS = "tedge mosquitto"

--- a/meta-tedge-rauc/conf/layer.conf
+++ b/meta-tedge-rauc/conf/layer.conf
@@ -5,13 +5,6 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-# Add layer-specific recipes
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bb' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-             
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-
 BBFILE_COLLECTIONS += "meta-tedge-rauc"
 BBFILE_PATTERN_meta-tedge-rauc = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tedge-rauc = "6"

--- a/meta-tedge-rauc/recipes-tedge/tedge-firmware-rauc/tedge-firmware-rauc.bb
+++ b/meta-tedge-rauc/recipes-tedge/tedge-firmware-rauc/tedge-firmware-rauc.bb
@@ -7,8 +7,6 @@ SRC_URI += " \
     file://persist.conf \
 "
 
-inherit logging
-
 DEPENDS = "tedge mosquitto"
 RDEPENDS:${PN} += " tedge"
 

--- a/meta-tedge/conf/layer.conf
+++ b/meta-tedge/conf/layer.conf
@@ -5,13 +5,6 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-# add recipes for subprojects
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bb' % layer \
-	for layer in BBFILE_COLLECTIONS.split())}"
-             
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
-	for layer in BBFILE_COLLECTIONS.split())}"
-
 BBFILE_COLLECTIONS += "meta-tedge"
 BBFILE_PATTERN_meta-tedge = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tedge = "6"

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -13,7 +13,6 @@ SUMMARY = "tedge is the cli tool for thin-edge.io"
 HOMEPAGE = "https://thin-edge.io"
 LICENSE = "Apache-2.0"
 
-inherit logging
 inherit cargo useradd
 
 RDEPENDS:${PN} = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo collectd"


### PR DESCRIPTION
Backporting some project cleanup as originally included in https://github.com/thin-edge/meta-tedge/pull/127.

The commits are being added to to the kirkstone branch so that the scarthgap can be rebased from kirksone for a clean git history.