### PR TITLE
refactor: use meta-lts-mixins layer for golang and Rust

### DIFF
--- a/kas/config/mender-raspberrypi.yaml
+++ b/kas/config/mender-raspberrypi.yaml
@@ -12,7 +12,7 @@ local_conf_header:
     IMAGE_FSTYPES:remove = " rpi-sdimg wic.bz2 wic.bmap"
     SDIMG_ROOTFS_TYPE = "ext4"
 
-    MENDER_STORAGE_TOTAL_SIZE_MB ?= "2048"
+    MENDER_STORAGE_TOTAL_SIZE_MB ?= "4096"
     MENDER_BOOT_PART_SIZE_MB ?= "64"
     MENDER_DATA_PART_SIZE_MB ?= "512"
 

--- a/kas/config/network.yaml
+++ b/kas/config/network.yaml
@@ -5,3 +5,5 @@ header:
 local_conf_header:
   meta-network: |
     IMAGE_INSTALL:append = " networkmanager networkmanager-bash-completion networkmanager-nmtui"
+    # Enable systemd-networkd and systemd-resolved
+    PACKAGECONFIG:append:pn-systemd = " networkd resolved"

--- a/kas/config/tedge-docker.yaml
+++ b/kas/config/tedge-docker.yaml
@@ -5,6 +5,8 @@ header:
 local_conf_header:
   meta-tedge-container-plugin: |
     DISTRO_FEATURES:append = " virtualization"
-    IMAGE_INSTALL:append = " docker-ce"
+    IMAGE_INSTALL:append = " docker"
+    # Control whether docker-ce or docker-moby is used
+    # PREFERRED_PROVIDER_virtual/docker ?= "docker-ce"
     IMAGE_INSTALL:append = " docker-compose"
     IMAGE_INSTALL:append = " tedge-container-plugin"

--- a/kas/projects/tedge-bin-rauc.lock.yaml
+++ b/kas/projects/tedge-bin-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     meta-lts-mixins-go:
-      commit: 7b4c22b4114c5789a6cb7d8b0b7c7078cd9f0dc9
+      commit: b8a6349ec476c0a38436be7503ef963f49c2c461
     meta-openembedded:
       commit: 4ad41baed6236d499804cbfc4f174042d84fce97
     meta-raspberrypi:

--- a/kas/projects/tedge-bin-rauc.lock.yaml
+++ b/kas/projects/tedge-bin-rauc.lock.yaml
@@ -5,14 +5,14 @@ overrides:
     meta-lts-mixins-go:
       commit: b8a6349ec476c0a38436be7503ef963f49c2c461
     meta-openembedded:
-      commit: 4ad41baed6236d499804cbfc4f174042d84fce97
+      commit: 7b3fdcdfaab2fc964bbf9eec2cce4e03001fa8cf
     meta-raspberrypi:
       commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
     meta-rauc:
-      commit: b27b59e2f9a3a7446f740b10560462076ef07009
+      commit: 930ea748b6c80e41e5cd3db12033cb1de88f7305
     meta-rauc-community:
       commit: fdaccecf6f950ccc21628aa2d8a5d7f9557eaabc
     meta-virtualization:
-      commit: c996df33763f292da5e7513c574272d7de23eafc
+      commit: a055d7dcafc58855081a5eac9a46b93b9b51012b
     poky:
-      commit: 8e092852b63e998d990b8f8e1aa91297dec4430f
+      commit: ce1fa3eec036c866e1c0fb091057349f203ea6a2

--- a/kas/projects/tedge-bin-rauc.yaml
+++ b/kas/projects/tedge-bin-rauc.yaml
@@ -64,7 +64,7 @@ repos:
       meta-raspberrypi:
 
   meta-lts-mixins-go:
-    url: "https://github.com/moto-timo/meta-lts-mixins.git"
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
     branch: kirkstone/go
 
   meta-virtualization:

--- a/kas/projects/tedge-mender-qemu.lock.yaml
+++ b/kas/projects/tedge-mender-qemu.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     meta-lts-mixins-go:
-      commit: 7b4c22b4114c5789a6cb7d8b0b7c7078cd9f0dc9
+      commit: b8a6349ec476c0a38436be7503ef963f49c2c461
     meta-mender:
       commit: 9efa9409684e303472ed9dae749ab663909eb689
     meta-openembedded:

--- a/kas/projects/tedge-mender-qemu.lock.yaml
+++ b/kas/projects/tedge-mender-qemu.lock.yaml
@@ -4,12 +4,12 @@ overrides:
   repos:
     meta-lts-mixins-go:
       commit: b8a6349ec476c0a38436be7503ef963f49c2c461
+    meta-lts-mixins-rust:
+      commit: 9bc06b6a761f28cf82aae8a99afe27ed5e2ce4c9
     meta-mender:
       commit: 9efa9409684e303472ed9dae749ab663909eb689
     meta-openembedded:
-      commit: 4ad41baed6236d499804cbfc4f174042d84fce97
-    meta-rust:
-      commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
+      commit: 7b3fdcdfaab2fc964bbf9eec2cce4e03001fa8cf
     meta-virtualization:
       commit: c996df33763f292da5e7513c574272d7de23eafc
     poky:

--- a/kas/projects/tedge-mender-qemu.lock.yaml
+++ b/kas/projects/tedge-mender-qemu.lock.yaml
@@ -7,10 +7,10 @@ overrides:
     meta-lts-mixins-rust:
       commit: 9bc06b6a761f28cf82aae8a99afe27ed5e2ce4c9
     meta-mender:
-      commit: 9efa9409684e303472ed9dae749ab663909eb689
+      commit: ca667e65861e0cec32dcefd8e4eb42b1bd82ed6d
     meta-openembedded:
       commit: 7b3fdcdfaab2fc964bbf9eec2cce4e03001fa8cf
     meta-virtualization:
-      commit: c996df33763f292da5e7513c574272d7de23eafc
+      commit: a055d7dcafc58855081a5eac9a46b93b9b51012b
     poky:
-      commit: 8e092852b63e998d990b8f8e1aa91297dec4430f
+      commit: ce1fa3eec036c866e1c0fb091057349f203ea6a2

--- a/kas/projects/tedge-mender-qemu.yaml
+++ b/kas/projects/tedge-mender-qemu.yaml
@@ -58,7 +58,7 @@ repos:
       meta-tedge-extras:
 
   meta-lts-mixins-go:
-    url: "https://github.com/moto-timo/meta-lts-mixins.git"
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
     branch: kirkstone/go
 
   meta-virtualization:

--- a/kas/projects/tedge-mender-qemu.yaml
+++ b/kas/projects/tedge-mender-qemu.yaml
@@ -45,9 +45,9 @@ repos:
       meta-mender-core:
       meta-mender-qemu:
 
-  meta-rust:
-    url: "https://github.com/meta-rust/meta-rust"
-    branch: master
+  meta-lts-mixins-rust:
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
+    branch: kirkstone/rust
 
   meta-tedge:
     path: ../../

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -7,12 +7,12 @@ overrides:
     meta-lts-mixins-rust:
       commit: 9bc06b6a761f28cf82aae8a99afe27ed5e2ce4c9
     meta-mender:
-      commit: 9efa9409684e303472ed9dae749ab663909eb689
+      commit: ca667e65861e0cec32dcefd8e4eb42b1bd82ed6d
     meta-openembedded:
-      commit: 4ad41baed6236d499804cbfc4f174042d84fce97
+      commit: 7b3fdcdfaab2fc964bbf9eec2cce4e03001fa8cf
     meta-raspberrypi:
       commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
     meta-virtualization:
-      commit: c996df33763f292da5e7513c574272d7de23eafc
+      commit: a055d7dcafc58855081a5eac9a46b93b9b51012b
     poky:
-      commit: 8e092852b63e998d990b8f8e1aa91297dec4430f
+      commit: ce1fa3eec036c866e1c0fb091057349f203ea6a2

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     meta-lts-mixins-go:
-      commit: 7b4c22b4114c5789a6cb7d8b0b7c7078cd9f0dc9
+      commit: b8a6349ec476c0a38436be7503ef963f49c2c461
     meta-mender:
       commit: 9efa9409684e303472ed9dae749ab663909eb689
     meta-openembedded:

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -4,14 +4,14 @@ overrides:
   repos:
     meta-lts-mixins-go:
       commit: b8a6349ec476c0a38436be7503ef963f49c2c461
+    meta-lts-mixins-rust:
+      commit: 9bc06b6a761f28cf82aae8a99afe27ed5e2ce4c9
     meta-mender:
       commit: 9efa9409684e303472ed9dae749ab663909eb689
     meta-openembedded:
       commit: 4ad41baed6236d499804cbfc4f174042d84fce97
     meta-raspberrypi:
       commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
-    meta-rust:
-      commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
     meta-virtualization:
       commit: c996df33763f292da5e7513c574272d7de23eafc
     poky:

--- a/kas/projects/tedge-mender.yaml
+++ b/kas/projects/tedge-mender.yaml
@@ -49,9 +49,9 @@ repos:
       meta-mender-core:
       meta-mender-raspberrypi:
 
-  meta-rust:
-    url: "https://github.com/meta-rust/meta-rust"
-    branch: master
+  meta-lts-mixins-rust:
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
+    branch: kirkstone/rust
 
   meta-tedge:
     path: ../../

--- a/kas/projects/tedge-mender.yaml
+++ b/kas/projects/tedge-mender.yaml
@@ -63,7 +63,7 @@ repos:
       meta-raspberrypi:
 
   meta-lts-mixins-go:
-    url: "https://github.com/moto-timo/meta-lts-mixins.git"
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
     branch: kirkstone/go
   
   meta-virtualization:

--- a/kas/projects/tedge-rauc.lock.yaml
+++ b/kas/projects/tedge-rauc.lock.yaml
@@ -7,14 +7,14 @@ overrides:
     meta-lts-mixins-rust:
       commit: 9bc06b6a761f28cf82aae8a99afe27ed5e2ce4c9
     meta-openembedded:
-      commit: 4ad41baed6236d499804cbfc4f174042d84fce97
+      commit: 7b3fdcdfaab2fc964bbf9eec2cce4e03001fa8cf
     meta-raspberrypi:
       commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
     meta-rauc:
-      commit: b27b59e2f9a3a7446f740b10560462076ef07009
+      commit: 930ea748b6c80e41e5cd3db12033cb1de88f7305
     meta-rauc-community:
       commit: fdaccecf6f950ccc21628aa2d8a5d7f9557eaabc
     meta-virtualization:
-      commit: c996df33763f292da5e7513c574272d7de23eafc
+      commit: a055d7dcafc58855081a5eac9a46b93b9b51012b
     poky:
-      commit: 8e092852b63e998d990b8f8e1aa91297dec4430f
+      commit: ce1fa3eec036c866e1c0fb091057349f203ea6a2

--- a/kas/projects/tedge-rauc.lock.yaml
+++ b/kas/projects/tedge-rauc.lock.yaml
@@ -4,6 +4,8 @@ overrides:
   repos:
     meta-lts-mixins-go:
       commit: b8a6349ec476c0a38436be7503ef963f49c2c461
+    meta-lts-mixins-rust:
+      commit: 9bc06b6a761f28cf82aae8a99afe27ed5e2ce4c9
     meta-openembedded:
       commit: 4ad41baed6236d499804cbfc4f174042d84fce97
     meta-raspberrypi:
@@ -12,8 +14,6 @@ overrides:
       commit: b27b59e2f9a3a7446f740b10560462076ef07009
     meta-rauc-community:
       commit: fdaccecf6f950ccc21628aa2d8a5d7f9557eaabc
-    meta-rust:
-      commit: a5136be2ba408af1cc8afcde1c8e3d787dadd934
     meta-virtualization:
       commit: c996df33763f292da5e7513c574272d7de23eafc
     poky:

--- a/kas/projects/tedge-rauc.lock.yaml
+++ b/kas/projects/tedge-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     meta-lts-mixins-go:
-      commit: 7b4c22b4114c5789a6cb7d8b0b7c7078cd9f0dc9
+      commit: b8a6349ec476c0a38436be7503ef963f49c2c461
     meta-openembedded:
       commit: 4ad41baed6236d499804cbfc4f174042d84fce97
     meta-raspberrypi:

--- a/kas/projects/tedge-rauc.yaml
+++ b/kas/projects/tedge-rauc.yaml
@@ -68,7 +68,7 @@ repos:
       meta-raspberrypi:
 
   meta-lts-mixins-go:
-    url: "https://github.com/moto-timo/meta-lts-mixins.git"
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
     branch: kirkstone/go
 
   meta-virtualization:

--- a/kas/projects/tedge-rauc.yaml
+++ b/kas/projects/tedge-rauc.yaml
@@ -54,9 +54,9 @@ repos:
     layers:
       meta-rauc-raspberrypi:
 
-  meta-rust:
-    url: "https://github.com/meta-rust/meta-rust"
-    branch: master
+  meta-lts-mixins-rust:
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
+    branch: kirkstone/rust
 
   meta-tedge:
     path: ../../

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
@@ -11,7 +11,7 @@ RDEPENDS:${PN} += " mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo 
 
 inherit bin_package useradd
 
-INSANE_SKIP:${PN} = "already-stripped"
+INSANE_SKIP:${PN} = "already-stripped usrmerge"
 
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM:${PN} = "--system --gid 950 tedge"

--- a/meta-tedge-common/conf/bblayers.conf.sample
+++ b/meta-tedge-common/conf/bblayers.conf.sample
@@ -13,7 +13,7 @@ BBLAYERS ?= " \
   /dir/to/layers/meta-openembedded/meta-python \
   /dir/to/layers/meta-openembedded/meta-networking \
   /dir/to/layers/meta-openembedded/meta-multimedia \
-  /dir/to/layers/meta-rust \
+  /dir/to/layers/meta-lts-mixins-rust \
   /dir/to/layers/meta-raspberrypi \
   /dir/to/layers/meta-tedge \
   /dir/to/layers/meta-mender/meta-mender-core \

--- a/meta-tedge-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-tedge-common/recipes-core/systemd/systemd_%.bbappend
@@ -1,3 +1,9 @@
+
+# Prevent NetworkManager from overriding systemd's (systemd-resolved) /etc/resolv.conf symlink
+# https://community.toradex.com/t/override-yocto-alternative-priority-with-bbappend/15596/2
+# increase priority from 50 to 150
+ALTERNATIVE_PRIORITY[resolv-conf] = "150"
+
 do_install:append () {
     if ${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', 'true', 'false', d)}; then
         # Set PrivateTmp=no as this systemd feature is incompatible with a read-only rootfs

--- a/meta-tedge/classes/cargo-tedge.bbclass
+++ b/meta-tedge/classes/cargo-tedge.bbclass
@@ -1,0 +1,15 @@
+inherit cargo 
+# This prevents disabling crates.io registry in cargo_do_configure task and
+# allows cargo to fetch dependencies during the do_compile step.
+#
+# It's still not perfect, because ideally we'd want to download all the source
+# code in the do_fetch step, but it's challenging because we'd have to either
+# duplicate do_configure step just for fetching, or swap the order and run
+# do_configure before do_fetch, which might be confusing for the users.
+do_compile[network] = "1"
+CARGO_DISABLE_BITBAKE_VENDORING = "1"
+
+# With the following commit: https://github.com/yoctoproject/poky/commit/d4c14304c92d76a2bdb612ffa3ca3477cd06cb6e
+# --frozen flag was introduced to supersed --offline flag and guarantee that Cargo.lock file will not be modified during the build.
+# In consequence it prevents network access that we need to load source for x509-parser library.
+CARGO_BUILD_FLAGS:remove = "--frozen"

--- a/meta-tedge/conf/layer.conf
+++ b/meta-tedge/conf/layer.conf
@@ -13,4 +13,4 @@ LAYERDEPENDS_meta-tedge = "core networking-layer"
 
 LAYERSERIES_COMPAT_meta-tedge = "kirkstone"
 
-RUSTVERSION ?= "1.78.0"
+RUSTVERSION ?= "1.80.1"

--- a/meta-tedge/conf/layer.conf
+++ b/meta-tedge/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "meta-tedge"
 BBFILE_PATTERN_meta-tedge = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tedge = "6"
 
-LAYERDEPENDS_meta-tedge = "core networking-layer rust-layer"
+LAYERDEPENDS_meta-tedge = "core networking-layer"
 
 LAYERSERIES_COMPAT_meta-tedge = "kirkstone"
 

--- a/meta-tedge/recipes-devtools/rust/libstd-rs_%.bbappend
+++ b/meta-tedge/recipes-devtools/rust/libstd-rs_%.bbappend
@@ -1,3 +1,0 @@
-# Fix issue with `proc_macro` crate not being included in stdlib
-
-S = "${RUSTSRC}/library/sysroot"

--- a/meta-tedge/recipes-tedge/tedge/tedge-services.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-services.inc
@@ -3,6 +3,20 @@ SRC_URI += "git://git@github.com/thin-edge/tedge-services.git;protocol=https;bra
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'update-rc.d', '', d)}
 
+# Fix issue with 'tedge-services' being treated as rust crate
+python fix_cargo_common_do_patch_paths() {
+    cargo_config = os.path.join(d.getVar("CARGO_HOME"), "config")
+    if not os.path.exists(cargo_config):
+        return
+    with open(cargo_config, "r") as config:
+        lines = config.readlines()
+    with open(cargo_config, "w") as config:
+        for line in lines:
+            if not "tedge-services" in line.strip("\n"):
+                config.write(line)
+}
+do_configure[postfuncs] += "fix_cargo_common_do_patch_paths"
+
 do_install:append () {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
 		install -d ${D}${systemd_system_unitdir}

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -1,4 +1,4 @@
-SRC_URI += "git://git@github.com/thin-edge/thin-edge.io.git;protocol=https;nobranch=1;branch=${PV};name=tedge"
+SRC_URI += "git://git@github.com/thin-edge/thin-edge.io.git;protocol=https;branch=main;name=tedge"
 
 SRC_URI += " \
     file://operations/c8y/c8y_RemoteAccessConnect \ 
@@ -13,29 +13,9 @@ SUMMARY = "tedge is the cli tool for thin-edge.io"
 HOMEPAGE = "https://thin-edge.io"
 LICENSE = "Apache-2.0"
 
-inherit cargo useradd
+inherit cargo-tedge useradd
 
 RDEPENDS:${PN} = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo collectd"
-
-# This prevents disabling crates.io registry in cargo_do_configure task and
-# allows cargo to fetch dependencies during the do_compile step.
-#
-# It's still not perfect, because ideally we'd want to download all the source
-# code in the do_fetch step, but it's challenging because we'd have to either
-# duplicate do_configure step just for fetching, or swap the order and run
-# do_configure before do_fetch, which might be confusing for the users.
-#
-# Still, it makes the update-layer.sh script entirely obsolete by significantly
-# improving the maintenance of the layer, simplifying updating to 2 steps:
-#
-# 1. Update recipe version and point to the new revision
-# 2. Handle package/systemd configuration changes, if any.
-#
-# We'll be looking into how to do it in do_fetch step, but as long as we don't
-# have it figured out, or somebody tells us we've broken their build, we're
-# going for this approach.
-do_compile[network] = "1"
-CARGO_DISABLE_BITBAKE_VENDORING = "1"
 
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM:${PN} = "--system --gid 950 tedge"


### PR DESCRIPTION
Use actively maintained "git.yoctoproject.org/meta-lts-mixins" repository over a mirror of it.

* Use `kirkstone/rust` branch instead of meta-rust
* Use `kirkstone/go` branch instead of moto-timo/meta-lts-mixins
* Change mender total storage size to 4096MB (this gives the user about 1.6GB on the root fs)

95% of the changed originated solely from @Ruadhri17 from https://github.com/thin-edge/meta-tedge/pull/127 and his [fork](https://github.com/thin-edge/meta-tedge/compare/kirkstone...Ruadhri17:meta-tedge:scarthgap) whilst updating for scarthgap (apologies from not pulling in the commit hashes)