### PR TITLE
feat(rauc): support updating linux kernel on updates

### DIFF
--- a/kas/config/rauc-raspberrypi.yaml
+++ b/kas/config/rauc-raspberrypi.yaml
@@ -7,7 +7,7 @@ local_conf_header:
     RPI_USE_U_BOOT = "1"
     IMAGE_INSTALL:append = " rauc rauc-grow-data-part"
     DISTRO_FEATURES:append = " rauc"
-    IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
+    IMAGE_INSTALL:append = " kernel-image kernel-modules kernel-devicetree"
     PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
     IMAGE_FSTYPES = " tar.bz2 ext4 wic.bz2 wic.bmap"
     SDIMG_ROOTFS_TYPE = "ext4"

--- a/kas/projects/tedge-bin-rauc.lock.yaml
+++ b/kas/projects/tedge-bin-rauc.lock.yaml
@@ -11,7 +11,7 @@ overrides:
     meta-rauc:
       commit: 930ea748b6c80e41e5cd3db12033cb1de88f7305
     meta-rauc-community:
-      commit: fdaccecf6f950ccc21628aa2d8a5d7f9557eaabc
+      commit: 4fcfbd5068fadd3541d6ef3317e81adb3120dad8
     meta-virtualization:
       commit: a055d7dcafc58855081a5eac9a46b93b9b51012b
     poky:

--- a/kas/projects/tedge-rauc.lock.yaml
+++ b/kas/projects/tedge-rauc.lock.yaml
@@ -13,7 +13,7 @@ overrides:
     meta-rauc:
       commit: 930ea748b6c80e41e5cd3db12033cb1de88f7305
     meta-rauc-community:
-      commit: fdaccecf6f950ccc21628aa2d8a5d7f9557eaabc
+      commit: 4fcfbd5068fadd3541d6ef3317e81adb3120dad8
     meta-virtualization:
       commit: a055d7dcafc58855081a5eac9a46b93b9b51012b
     poky:


### PR DESCRIPTION
Update the meta-rauc-community kirkstone fork which includes two commits ported from scarthgap where this feature was already added.

This allows users to update from a kirkstone image to scarthgap.