### PR TITLE
fix: raspberry pi wifi setup

### DIFF
--- a/kas/config/raspberrypi.yaml
+++ b/kas/config/raspberrypi.yaml
@@ -5,6 +5,6 @@ header:
 local_conf_header:
   meta-raspberrypi: |
     DISTRO_FEATURES:append = " bluez5 bluetooth wifi "
-    IMAGE_INSTALL:append = " linux-firmware-rpidistro-bcm43430 bluez5 i2c-tools"
+    IMAGE_INSTALL:append = " bluez5 i2c-tools"
     ENABLE_UART = "1"
     LICENSE_FLAGS_ACCEPTED = "synaptics-killswitch"

--- a/kas/projects/tedge-bin-rauc.lock.yaml
+++ b/kas/projects/tedge-bin-rauc.lock.yaml
@@ -11,7 +11,7 @@ overrides:
     meta-rauc:
       commit: 8f35e94b406ef9ec466a6125971b40f51ae139eb
     meta-rauc-community:
-      commit: 47963bd17671b7fc71d636fa43783f5de101042c
+      commit: 935ea34c32fcdc70b5f48a7f6a6a32b1af65081d
     meta-virtualization:
       commit: 450941a1b6df96285691e8c23d4f332d3c88a994
     poky:

--- a/kas/projects/tedge-rauc.lock.yaml
+++ b/kas/projects/tedge-rauc.lock.yaml
@@ -11,7 +11,7 @@ overrides:
     meta-rauc:
       commit: 8f35e94b406ef9ec466a6125971b40f51ae139eb
     meta-rauc-community:
-      commit: 47963bd17671b7fc71d636fa43783f5de101042c
+      commit: 935ea34c32fcdc70b5f48a7f6a6a32b1af65081d
     meta-virtualization:
       commit: 450941a1b6df96285691e8c23d4f332d3c88a994
     poky:


### PR DESCRIPTION
Avoid explicitly installing the raspberry pi4 specific firmware to avoid problems when the firmware isn't support on other devices. Use the updated rauc community fork to enable loading the device tree from the root file system.