### PR TITLE
chore: backport scarthgap fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The repository follows the release-named branch strategy. Only LTS releases are 
 | Yocto Release | thin-edge version | Branch Name | Branch Status |
 | :- | :- | :- | :- |
 | Kirkstone | 1.x | kirkstone | Active and maintained |
-| Scarthgap | 1.x | scarthgap | In development (soon to be supported) |
+| Scarthgap | 1.x | scarthgap | Active and maintained |
 
 ## Contributing
 

--- a/kas/config/mender-raspberrypi.yaml
+++ b/kas/config/mender-raspberrypi.yaml
@@ -9,6 +9,7 @@ local_conf_header:
     SYSTEMD_AUTO_ENABLE:pn-mender-client = "disable"
     RPI_USE_U_BOOT = "1"
     IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
+    IMAGE_FSTYPES:append = " sdimg.bz2"
     IMAGE_FSTYPES:remove = " rpi-sdimg wic.bz2 wic.bmap"
     SDIMG_ROOTFS_TYPE = "ext4"
 

--- a/kas/config/raspberrypi.yaml
+++ b/kas/config/raspberrypi.yaml
@@ -5,5 +5,5 @@ header:
 local_conf_header:
   meta-raspberrypi: |
     DISTRO_FEATURES:append = " bluez5 bluetooth wifi "
-    IMAGE_INSTALL:append = " linux-firmware-rpidistro-bcm43430 bluez5 i2c-tools"
+    IMAGE_INSTALL:append = " bluez5 i2c-tools"
     ENABLE_UART = "1"

--- a/kas/projects/tedge-bin-rauc.lock.yaml
+++ b/kas/projects/tedge-bin-rauc.lock.yaml
@@ -11,7 +11,7 @@ overrides:
     meta-rauc:
       commit: 930ea748b6c80e41e5cd3db12033cb1de88f7305
     meta-rauc-community:
-      commit: 4fcfbd5068fadd3541d6ef3317e81adb3120dad8
+      commit: cfc8901f68f931cebbb4d48759368bb263d977d4
     meta-virtualization:
       commit: a055d7dcafc58855081a5eac9a46b93b9b51012b
     poky:

--- a/kas/projects/tedge-rauc.lock.yaml
+++ b/kas/projects/tedge-rauc.lock.yaml
@@ -13,7 +13,7 @@ overrides:
     meta-rauc:
       commit: 930ea748b6c80e41e5cd3db12033cb1de88f7305
     meta-rauc-community:
-      commit: 4fcfbd5068fadd3541d6ef3317e81adb3120dad8
+      commit: cfc8901f68f931cebbb4d48759368bb263d977d4
     meta-virtualization:
       commit: a055d7dcafc58855081a5eac9a46b93b9b51012b
     poky:


### PR DESCRIPTION
Backport some minor changes from scarthgap to kirkstone:

* docs: update scarthgap status on kirkstone readme
* Don't explicitly install raspberry pi wifi firmware
* Add image fs type for mender images (to reduce number of differences between kirkstone and scarthgap)