### PR TITLE
fix: remove firmware meta info workaround

### DIFF
--- a/meta-tedge-common/recipes-tedge/tedge-inventory/tedge-inventory/firmware-version
+++ b/meta-tedge-common/recipes-tedge/tedge-inventory/tedge-inventory/firmware-version
@@ -46,8 +46,3 @@ fi
 
 echo "name=\"$NAME\""
 echo "version=\"$VERSION\""
-
-# FIXME: Workaround since thin-edge.io does deduplication detection.
-# However this is only needed because the firmware/name is cleared on tedge-agent startup.
-# Remove once https://github.com/thin-edge/thin-edge.io/issues/2497 is resolved
-echo "updated=\"$(date)\""

--- a/meta-tedge-common/recipes-tedge/tedge-inventory/tedge-inventory_git.bb
+++ b/meta-tedge-common/recipes-tedge/tedge-inventory/tedge-inventory_git.bb
@@ -25,7 +25,7 @@ do_install () {
         install -m 0755 "$file" "${D}${datadir}/tedge-inventory/scripts.d"
     done
 
-    install -m 0755 "${WORKDIR}/firmware-version" "${D}${datadir}/tedge-inventory/scripts.d/80_c8y_Firmware"
+    install -m 0755 "${WORKDIR}/firmware-version" "${D}${datadir}/tedge-inventory/scripts.d/80_firmware"
 
     install -d "${D}${systemd_system_unitdir}"
     for file in ${S}/src/services/systemd/tedge-inventory*; do


### PR DESCRIPTION
Remove workaround (https://github.com/thin-edge/meta-tedge/issues/67). Rename the firmware update script to use the generic `firmware` interface instead of the Cumulocity specific `c8y_Firmware` property.