### PR TITLE
fix(scarthgap-collectd): enable collectd mqtt plugin

### DIFF
--- a/kas/config/monitor.yaml
+++ b/kas/config/monitor.yaml
@@ -5,3 +5,8 @@ header:
 local_conf_header:
   meta-monitor: |
     IMAGE_INSTALL:append = " monit"
+
+    # collectd
+    IMAGE_INSTALL:append = " libmosquitto1 libmosquittopp1"
+    PACKAGECONFIG:append:pn-collectd = " mqtt"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-collectd = "enable"

--- a/meta-tedge-common/recipes-core/collectd/collectd_%.bbappend
+++ b/meta-tedge-common/recipes-core/collectd/collectd_%.bbappend
@@ -1,0 +1,6 @@
+# Enable mqtt plugin
+PACKAGECONFIG[mqtt] = "--with-libmosquitto,--without-libmosquitto,mosquitto"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/collectd/collectd.conf.d
+}

--- a/meta-tedge-common/recipes-core/collectd/collectd_%.bbappend
+++ b/meta-tedge-common/recipes-core/collectd/collectd_%.bbappend
@@ -3,4 +3,6 @@ PACKAGECONFIG[mqtt] = "--with-libmosquitto,--without-libmosquitto,mosquitto"
 
 do_install:append() {
     install -d ${D}${sysconfdir}/collectd/collectd.conf.d
+    # The collectd.conf file is provided by a symlink in the tedge recipe
+    rm -f ${D}${sysconfdir}/collectd.conf
 }

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -40,6 +40,7 @@ do_install:append () {
     # install collectd for tedge-mapper
     install -d ${D}${TEDGE_CONFIG_DIR}/contrib/collectd
     install -m 0644 ${S}/configuration/contrib/collectd/collectd.conf ${D}${TEDGE_CONFIG_DIR}/contrib/collectd
+    ln -sf -r  ${D}${TEDGE_CONFIG_DIR}/contrib/collectd/collectd.conf ${D}${sysconfdir}/collectd.conf
 
     # Create symlink for tedge-apt-plugin in `/etc/tedge/sm-plugins`
     install -d ${D}${TEDGE_CONFIG_DIR}/sm-plugins
@@ -75,6 +76,7 @@ do_install:append () {
 
 FILES:${PN} = "\ 
     ${bindir}/* \
+    ${sysconfdir}/collectd.conf \
     ${TEDGE_CONFIG_SYMLINK} \
     ${TEDGE_CONFIG_DIR} \
     ${TEDGE_CONFIG_DIR}/tedge.toml \


### PR DESCRIPTION
Add collectd bbappends to build collectd with the mqtt plugin (which is required by the thin-edge.io integration):

Changes:

* build collectd with the mqtt plugin (which uses libmosquitto)
* use tedge's collectd.conf file (by way of symlink)
* enable tedge-mapper-collectd by default

Resolves https://github.com/thin-edge/meta-tedge/issues/72