### PR TITLE
fix(kirkstone): simplify tedge-service installation and fix `tedge_exclude`

### DIFF
--- a/meta-tedge/classes/cargo-tedge.bbclass
+++ b/meta-tedge/classes/cargo-tedge.bbclass
@@ -9,6 +9,19 @@ inherit cargo
 do_compile[network] = "1"
 CARGO_DISABLE_BITBAKE_VENDORING = "1"
 
+# The function cargo_common_do_patch_paths adds extra Git repositories with `name` and `destsuffix` from `SRC_URI`  
+# to the Cargo configuration as a patch so that they will be built during the do_compile step with Cargo.  
+#  
+# However, we add a repository with services that meet these conditions but have nothing  
+# to do with Rust code, so we skip this postfunction to prevent errors.  
+#  
+# Note: If we plan to compile two Rust repositories in a single recipe in the future, this change  
+# must be reverted, and cargo_common_do_patch_paths must be redesigned. However, for now,  
+# it is simpler to just skip it.  
+python cargo_common_do_patch_paths:prepend () {
+    return
+} 
+
 # With the following commit: https://github.com/yoctoproject/poky/commit/d4c14304c92d76a2bdb612ffa3ca3477cd06cb6e
 # --frozen flag was introduced to supersed --offline flag and guarantee that Cargo.lock file will not be modified during the build.
 # In consequence it prevents network access that we need to load source for x509-parser library.

--- a/meta-tedge/recipes-tedge/tedge/tedge-services.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-services.inc
@@ -3,20 +3,6 @@ SRC_URI += "git://git@github.com/thin-edge/tedge-services.git;protocol=https;bra
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'update-rc.d', '', d)}
 
-# Fix issue with 'tedge-services' being treated as rust crate
-python fix_cargo_common_do_patch_paths() {
-    cargo_config = os.path.join(d.getVar("CARGO_HOME"), "config")
-    if not os.path.exists(cargo_config):
-        return
-    with open(cargo_config, "r") as config:
-        lines = config.readlines()
-    with open(cargo_config, "w") as config:
-        for line in lines:
-            if not "tedge-services" in line.strip("\n"):
-                config.write(line)
-}
-do_configure[postfuncs] += "fix_cargo_common_do_patch_paths"
-
 do_install:append () {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
 		install -d ${D}${systemd_system_unitdir}

--- a/meta-tedge/recipes-tedge/tedge/tedge-services.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-services.inc
@@ -6,9 +6,10 @@ inherit ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'update-rc.d', '', d
 do_install:append () {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
 		install -d ${D}${systemd_system_unitdir}
+        
         for service in ${WORKDIR}/tedge-services/services/systemd/system/*; do
             filename=$(basename "$service" ".service" | cut -d. -f1)
-            if ${@bb.utils.contains('TEDGE_EXCLUDE', "$filename", 'false', 'true', d)}; then
+            if ! echo "${@d.getVar('TEDGE_EXCLUDE')}" | grep -iq $filename; then
                 install -m 0644 $service ${D}${systemd_system_unitdir}
             fi
         done 
@@ -16,7 +17,7 @@ do_install:append () {
         install -d ${D}${sysconfdir}/init.d
         for service in ${WORKDIR}/tedge-services/services/sysvinit-yocto/init.d/*; do
             filename=$(basename -- "$service")
-            if ${@bb.utils.contains('TEDGE_EXCLUDE', "$filename", 'false', 'true', d)}; then
+            if ! echo "${@d.getVar('TEDGE_EXCLUDE')}" | grep -iq $filename; then
                 install -m 0755 $service ${D}${sysconfdir}/init.d
             fi
         done 
@@ -34,7 +35,7 @@ do_install:append () {
     fi
 }
 
-PACKAGES += "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-c8y-firmware-plugin"
+PACKAGES += "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd"
 
 FILES:${PN} += "\
     ${sysconfdir}/init.d/* \
@@ -60,17 +61,10 @@ FILES:${PN}-mapper-az += "\
 FILES:${PN}-mapper-collectd += "\
     ${systemd_system_unitdir}/tedge-mapper-collectd.service \
 "
-FILES:${PN}-c8y-firmware-plugin += "\
-    ${systemd_system_unitdir}/c8y-firmware-plugin.service \
-"
 
-SYSTEMD_PACKAGES = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-c8y-firmware-plugin"
+SYSTEMD_PACKAGES = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd"
 SYSTEMD_SERVICE:${PN}-agent = "tedge-agent.service"
 SYSTEMD_SERVICE:${PN}-mapper-c8y = "tedge-mapper-c8y.service c8y-remote-access-plugin@.service c8y-remote-access-plugin.socket"
 SYSTEMD_SERVICE:${PN}-mapper-aws = "tedge-mapper-aws.service"
 SYSTEMD_SERVICE:${PN}-mapper-az = "tedge-mapper-az.service"
 SYSTEMD_SERVICE:${PN}-mapper-collectd = "tedge-mapper-collectd.service"
-SYSTEMD_SERVICE:${PN}-c8y-firmware-plugin = "c8y-firmware-plugin.service"
-
-# Disable c8y-firmware-plugin as this is deprecated
-SYSTEMD_AUTO_ENABLE:${PN}-c8y-firmware-plugin = "disable"


### PR DESCRIPTION
(#143) We can't move `tedge-service` as standalone recipe due to issue with package versioning. For now, the process of removing this recipe from `cargo` is simplified. Additionally, this PR fixes issue with `TEDGE_EXCLUDE` not working for services (c8y-firmware-plugin was not removed and service had to be disabled manually)