### PR TITLE
ci: fix the base branch used when creating the PR

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -50,4 +50,4 @@ jobs:
           git commit -am "Update ${{github.ref_name}} branch"
           git push --set-upstream origin "$PR_BRANCH"
           gh repo set-default ${{github.repository}}
-          gh pr create --title "Update version" --body "Update version" --label ci
+          gh pr create --base "${{github.ref_name}}" --title "Update version" --body "Update version" --label ci


### PR DESCRIPTION
By default the default branch is used which leads to the scarthgap pr being raised against the kirkstone branch