### PR TITLE
feat(scarthgap): store yocto buildinfo under /etc/buildinfo

### DIFF
--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -15,8 +15,9 @@ local_conf_header:
     INIT_MANAGER="systemd"
     TEDGE_CONFIG_DIR = "/etc/tedge"
 
-    # Add /etc/build file with information about build
+    # Add /etc/buildinfo file with information about build
     INHERIT += "image-buildinfo"
+    IMAGE_BUILDINFO_FILE = "${sysconfdir}/buildinfo"
     IMAGE_BUILDINFO_VARS:append = " DATETIME DISTRO_NAME IMAGE_BASENAME IMAGE_NAME IMAGE_NAME_SUFFIX MACHINE TUNE_PKGARCH" 
     IMAGE_BUILDINFO_VARS:append = " MACHINE_FEATURES DISTRO_FEATURES COMMON_FEATURES IMAGE_FEATURES"
     IMAGE_BUILDINFO_VARS:append = " TUNE_FEATURES TARGET_FPU"

--- a/meta-tedge-common/recipes-tedge/tedge-bootstrap/tedge-bootstrap/tedge-identity
+++ b/meta-tedge-common/recipes-tedge/tedge-bootstrap/tedge-bootstrap/tedge-identity
@@ -44,16 +44,17 @@ get_mac_address() {
 
 read_from_build_file() {
     PROPERTY="$1"
-    if [ ! -f /etc/build ]; then
+    BUILD_INFO_FILE=/etc/buildinfo
+    if [ ! -f "$BUILD_INFO_FILE" ]; then
         return 1
     fi
-    value=$(grep "^$PROPERTY =" /etc/build | cut -d= -f2- | xargs)
+    value=$(grep "^$PROPERTY =" "$BUILD_INFO_FILE" | cut -d= -f2- | xargs)
     if [ -z "$value" ]; then
         return 1
     fi
     echo "$value"
 
-    echo "Reading the model prefix from the $PROPERTY property of /etc/build" >&2
+    echo "Reading the model prefix from the $PROPERTY property of '$BUILD_INFO_FILE'" >&2
 }
 
 get_model_type() {

--- a/meta-tedge-common/recipes-tedge/tedge-inventory/tedge-inventory/firmware-version
+++ b/meta-tedge-common/recipes-tedge/tedge-inventory/tedge-inventory/firmware-version
@@ -11,6 +11,7 @@ set -e
 
 NAME=
 VERSION=
+BUILD_INFO_FILE=/etc/buildinfo
 
 read_from_mender() {
     # Parse mender artifact to name and version
@@ -27,16 +28,14 @@ read_from_mender() {
 }
 
 read_from_yocto_build() {
-    NAME=$(grep "IMAGE_BASENAME = " /etc/build | cut -d = -f2- | xargs)
-    VERSION=$(grep "IMAGE_NAME = " /etc/build | cut -d = -f2- | rev | cut -d_ -f1 | rev | xargs)
-    # Alternative version (using DATETIME)
-    # VERSION=$(grep "DATETIME = " /etc/build | cut -d = -f2- | xargs)
+    NAME=$(grep "IMAGE_BASENAME = " "$1" | cut -d = -f2- | xargs)
+    VERSION=$(grep "IMAGE_NAME = " "$1" | cut -d = -f2- | rev | cut -d_ -f1 | rev | xargs)
 }
 
 if command -v mender >/dev/null 2>&1; then
     read_from_mender
-elif [ -f /etc/build ]; then
-    read_from_yocto_build
+elif [ -f "$BUILD_INFO_FILE" ]; then
+    read_from_yocto_build "$BUILD_INFO_FILE"
 fi
 
 if [ -z "$NAME" ] || [ -z "$VERSION" ]; then


### PR DESCRIPTION
In scarthgap, the default location changed from `/etc/build` to `/etc/buildinfo`. Explicitly set the buildinfo path to align with the scarthgap.

The scripts which rely on reading the build info file have also been updated to use the new /etc/buildinfo path (though it is not configurable).

References:
* Poky kirkstone: https://git.yoctoproject.org/poky/tree/meta/classes/image-buildinfo.bbclass?h=kirkstone
* Poky scarthgap: https://git.yoctoproject.org/poky/tree/meta/classes/image-buildinfo.bbclass?h=scarthgap