### PR TITLE
fix(scarthgap): remove duplicated packages from image recipe

### DIFF
--- a/meta-tedge-rauc/recipes-core/images/core-image-tedge-rauc.bb
+++ b/meta-tedge-rauc/recipes-core/images/core-image-tedge-rauc.bb
@@ -2,8 +2,6 @@ require recipes-core/images/core-image-tedge.bb
 
 IMAGE_INSTALL:append = " \
     tedge-firmware-rauc \
-    ${@bb.utils.contains('INIT_MANAGER','systemd','tedge-bootstrap','',d)} \
-    ${@bb.utils.contains('INIT_MANAGER','systemd','tedge-sethostname','',d)} \
 "
 
 # Optimizations for RAUC adaptive method 'block-hash-index'


### PR DESCRIPTION
In `core-image-tedge-rauc`, we add `tedge-sethostname` and `tedge-inventory` that have been already added in `core-image-tedge`.  This PR removes that package duplication.