### PR TITLE
feat(scarthgap): add tedge-p11-server and tedge-cert-renewer services

### DIFF
--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -15,6 +15,10 @@ local_conf_header:
     INIT_MANAGER="systemd"
     TEDGE_CONFIG_DIR = "/etc/tedge"
 
+    # preferred thin-edge.io version
+    # Use "1.5%" if you want to use the latest from the main branch
+    PREFERRED_VERSION_tedge ?= "1.4.2"
+
     # Add /etc/buildinfo file with information about build
     INHERIT += "image-buildinfo"
     IMAGE_BUILDINFO_FILE = "${sysconfdir}/buildinfo"
@@ -31,3 +35,4 @@ local_conf_header:
     SYSTEMD_AUTO_ENABLE:tedge-mapper-aws = "disable"
     SYSTEMD_AUTO_ENABLE:tedge-mapper-az = "disable"
     SYSTEMD_AUTO_ENABLE:tedge-mapper-collectd = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-p11-server = "enable"

--- a/kas/config/read-only.yaml
+++ b/kas/config/read-only.yaml
@@ -18,6 +18,7 @@ local_conf_header:
     SYSTEMD_AUTO_ENABLE:tedge-mapper-aws = "disable"
     SYSTEMD_AUTO_ENABLE:tedge-mapper-az = "disable"
     SYSTEMD_AUTO_ENABLE:tedge-mapper-collectd = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-p11-server = "enable"
 
     # `has_journal` interferes with the checksum of the image when viewed from the block device. Oddly
     # enough it is not present on disk, IOW, when the image is mounted readonly, the physical checksum

--- a/meta-tedge/recipes-tedge/tedge/tedge-services.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-services.inc
@@ -35,7 +35,7 @@ do_install:append () {
     fi
 }
 
-PACKAGES += "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd"
+PACKAGES += "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-p11-server"
 
 FILES:${PN} += "\
     ${sysconfdir}/init.d/* \
@@ -51,6 +51,9 @@ FILES:${PN}-mapper-c8y += "\
     ${systemd_system_unitdir}/tedge-mapper-c8y.service \
     ${systemd_system_unitdir}/c8y-remote-access-plugin@.service \
     ${systemd_system_unitdir}/c8y-remote-access-plugin.socket \
+    ${systemd_system_unitdir}/tedge-cert-renewer@.service \
+    ${systemd_system_unitdir}/tedge-cert-renewer@.timer \
+    ${systemd_system_unitdir}/tedge-cert-renewer.target \
 "
 FILES:${PN}-mapper-aws += "\
     ${systemd_system_unitdir}/tedge-mapper-aws.service \
@@ -61,10 +64,15 @@ FILES:${PN}-mapper-az += "\
 FILES:${PN}-mapper-collectd += "\
     ${systemd_system_unitdir}/tedge-mapper-collectd.service \
 "
+FILES:${PN}-p11-server += "\
+    ${systemd_system_unitdir}/tedge-p11-server.service \
+    ${systemd_system_unitdir}/tedge-p11-server.socket \
+"
 
-SYSTEMD_PACKAGES = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd"
+SYSTEMD_PACKAGES = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-p11-server"
 SYSTEMD_SERVICE:${PN}-agent = "tedge-agent.service"
 SYSTEMD_SERVICE:${PN}-mapper-c8y = "tedge-mapper-c8y.service c8y-remote-access-plugin@.service c8y-remote-access-plugin.socket"
 SYSTEMD_SERVICE:${PN}-mapper-aws = "tedge-mapper-aws.service"
 SYSTEMD_SERVICE:${PN}-mapper-az = "tedge-mapper-az.service"
 SYSTEMD_SERVICE:${PN}-mapper-collectd = "tedge-mapper-collectd.service"
+SYSTEMD_SERVICE:${PN}-p11-server = "tedge-p11-server.socket"

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -15,7 +15,7 @@ LICENSE = "Apache-2.0"
 
 inherit cargo-tedge useradd
 
-RDEPENDS:${PN} = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo collectd"
+RDEPENDS:${PN} = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-p11-server mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo collectd"
 
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM:${PN} = "--system --gid 950 tedge"

--- a/meta-tedge/recipes-tedge/tedge/tedge_git.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_git.bb
@@ -1,0 +1,9 @@
+SRCREV_tedge = "${AUTOREV}"
+SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_FORMAT = "tedge"
+S = "${WORKDIR}/git"
+PV = "1.5+git${SRCPV}"
+
+TEDGE_EXCLUDE = "c8y-firmware-plugin"
+
+require tedge.inc


### PR DESCRIPTION
Add tedge-p11-server and tedge-cert-renewer services which are included in the upcoming thin-edge.io 1.5.0 release.

The change also includes a new tedge_git.bb file which allows users to build from the thin-edge.io main branch instead of using the official release, however the preferred version will still be set to the last official release by default.