### PR TITLE
fix(scarthgap): add default listener to enable MQTT broker before bootstrapping

### DIFF
--- a/meta-tedge-bin/recipes-tedge/tedge-bin/files/mosquitto-conf/tedge-mosquitto.conf
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/files/mosquitto-conf/tedge-mosquitto.conf
@@ -1,0 +1,12 @@
+per_listener_settings true
+connection_messages true
+log_type error
+log_type warning
+log_type notice
+log_type information
+log_type subscribe
+log_type unsubscribe
+message_size_limit 268435455
+listener 1883 127.0.0.1
+allow_anonymous true
+require_certificate false

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
@@ -5,6 +5,7 @@ LICENSE = "CLOSED"
 SRC_URI += " \
     file://operations/c8y/c8y_RemoteAccessConnect \ 
     file://tedge.toml \
+    file://mosquitto-conf/tedge-mosquitto.conf \
 "
 
 RDEPENDS:${PN} += " mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo collectd"
@@ -45,6 +46,7 @@ do_install:append () {
     # Initialize the tedge
     install -m 0644 "${WORKDIR}/operations/c8y/"* ${D}${TEDGE_CONFIG_DIR}/operations/c8y/
     install -m 0644 "${WORKDIR}/tedge.toml" ${D}${TEDGE_CONFIG_DIR}/
+    install -m 0644 "${WORKDIR}/mosquitto-conf/tedge-mosquitto.conf" ${D}${TEDGE_CONFIG_DIR}/mosquitto-conf/
 
     # Create symlinks
     ln --relative --symbolic ${D}${bindir}/tedge ${D}${bindir}/tedge-agent
@@ -108,6 +110,7 @@ FILES:${PN} += "\
     ${TEDGE_CONFIG_DIR} \
     ${TEDGE_CONFIG_DIR}/tedge.toml \
     ${TEDGE_CONFIG_DIR}/operations/c8y/c8y_RemoteAccessConnect \
+    ${TEDGE_CONFIG_DIR}/mosquitto-conf/tedge-mosquitto.conf \
     ${TEDGE_CONFIG_DIR}/contrib/collectd \
     ${TEDGE_CONFIG_DIR}/sm-plugins/apt \
 "

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -3,6 +3,7 @@ SRC_URI += "git://git@github.com/thin-edge/thin-edge.io.git;protocol=https;branc
 SRC_URI += " \
     file://operations/c8y/c8y_RemoteAccessConnect \ 
     file://tedge.toml \
+    file://mosquitto-conf/tedge-mosquitto.conf \
 "
 
 LIC_FILES_CHKSUM = " \
@@ -54,6 +55,7 @@ do_install:append () {
     # Initialize the tedge
     install -m 0644 "${WORKDIR}/operations/c8y/"* ${D}${TEDGE_CONFIG_DIR}/operations/c8y/
     install -m 0644 "${WORKDIR}/tedge.toml" ${D}${TEDGE_CONFIG_DIR}/
+    install -m 0644 "${WORKDIR}/mosquitto-conf/tedge-mosquitto.conf" ${D}${TEDGE_CONFIG_DIR}/mosquitto-conf/
 
     # Create symlinks
     ln --relative --symbolic ${D}${bindir}/tedge ${D}${bindir}/tedge-agent
@@ -81,6 +83,7 @@ FILES:${PN} = "\
     ${TEDGE_CONFIG_DIR} \
     ${TEDGE_CONFIG_DIR}/tedge.toml \
     ${TEDGE_CONFIG_DIR}/operations/c8y/c8y_RemoteAccessConnect \
+    ${TEDGE_CONFIG_DIR}/mosquitto-conf/tedge-mosquitto.conf \
     ${TEDGE_CONFIG_DIR}/contrib/collectd \
     ${TEDGE_CONFIG_DIR}/sm-plugins/apt \
 "

--- a/meta-tedge/recipes-tedge/tedge/tedge/mosquitto-conf/tedge-mosquitto.conf
+++ b/meta-tedge/recipes-tedge/tedge/tedge/mosquitto-conf/tedge-mosquitto.conf
@@ -1,0 +1,12 @@
+per_listener_settings true
+connection_messages true
+log_type error
+log_type warning
+log_type notice
+log_type information
+log_type subscribe
+log_type unsubscribe
+message_size_limit 268435455
+listener 1883 127.0.0.1
+allow_anonymous true
+require_certificate false


### PR DESCRIPTION
Add the default mosquitto listener on port 1883 so that the MQTT is funcitonal on the default port before the device is bootstrapped.

Now, the following command can be used before the device is bootstrapped:

```
tedge mqtt sub '#'
```