### PR TITLE
feat(scarthgap): tab completion recipes and zsh as default shell

### DIFF
--- a/meta-tedge-common/recipes-core/images/core-image-tedge.bb
+++ b/meta-tedge-common/recipes-core/images/core-image-tedge.bb
@@ -3,7 +3,25 @@ require recipes-core/images/core-image-base.bb
 IMAGE_INSTALL:append = " \
     tedge \
     tedge-command-plugin \
+    opensc \
+    gnutls-bin \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'tedge-bootstrap', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'tedge-sethostname', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'tedge-inventory', '', d)} \
 "
+
+# Set default shell
+ROOTFS_POSTPROCESS_COMMAND += "change_default_shell;"
+change_default_shell() {
+    [ -f ${IMAGE_ROOTFS}/bin/zsh ] && chsh -R ${IMAGE_ROOTFS} -s /bin/zsh
+}
+
+# Create default bashrc file
+ROOTFS_POSTPROCESS_COMMAND += "modify_default_bashrc;"
+modify_default_bashrc() {
+    if [ -f ${IMAGE_ROOTFS}/etc/skel/.bashrc ]; then
+        echo '[ -f /etc/bash_completion ] && . /etc/bash_completion' >> ${IMAGE_ROOTFS}/etc/skel/.bashrc
+    fi
+
+    cp ${IMAGE_ROOTFS}${sysconfdir}/skel/.bashrc ${IMAGE_ROOTFS}${ROOT_HOME}/.bashrc
+}

--- a/meta-tedge-common/recipes-tedge/tedge-completions-bash/tedge-completions-bash.bb
+++ b/meta-tedge-common/recipes-tedge/tedge-completions-bash/tedge-completions-bash.bb
@@ -1,0 +1,20 @@
+SUMMARY = "bash-completions for tedge"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10" 
+
+inherit allarch
+
+RDEPENDS:${PN} += "bash-completion"
+
+SRC_URI += " \
+    file://tedge-completions.bash \
+"
+
+do_install () {
+    install -d "${D}${datadir}/bash-completion/completions"
+    install -m 0644 "${WORKDIR}/tedge-completions.bash" "${D}${datadir}/bash-completion/completions/tedge"
+}
+
+FILES:${PN} += " \
+    ${datadir}/bash-completion/completions/tedge \
+"

--- a/meta-tedge-common/recipes-tedge/tedge-completions-bash/tedge-completions-bash/tedge-completions.bash
+++ b/meta-tedge-common/recipes-tedge/tedge-completions-bash/tedge-completions-bash/tedge-completions.bash
@@ -1,0 +1,27 @@
+_clap_complete_tedge() {
+    local IFS=$'\013'
+    local _CLAP_COMPLETE_INDEX=${COMP_CWORD}
+    local _CLAP_COMPLETE_COMP_TYPE=${COMP_TYPE}
+    if compopt +o nospace 2> /dev/null; then
+        local _CLAP_COMPLETE_SPACE=false
+    else
+        local _CLAP_COMPLETE_SPACE=true
+    fi
+    COMPREPLY=( $( \
+        _CLAP_IFS="$IFS" \
+        _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
+        _CLAP_COMPLETE_COMP_TYPE="$_CLAP_COMPLETE_COMP_TYPE" \
+        COMPLETE="bash" \
+        "/usr/bin/tedge" -- "${COMP_WORDS[@]}" \
+    ) )
+    if [[ $? != 0 ]]; then
+        unset COMPREPLY
+    elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
+        compopt -o nospace
+    fi
+}
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -o nospace -o bashdefault -o nosort -F _clap_complete_tedge tedge
+else
+    complete -o nospace -o bashdefault -F _clap_complete_tedge tedge
+fi

--- a/meta-tedge-common/recipes-tedge/tedge-completions-zsh/tedge-completions-zsh.bb
+++ b/meta-tedge-common/recipes-tedge/tedge-completions-zsh/tedge-completions-zsh.bb
@@ -1,0 +1,25 @@
+SUMMARY = "zsh-completions for tedge"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10" 
+
+inherit allarch
+
+RDEPENDS:${PN} += "zsh"
+
+SRC_URI += " \
+    file://tedge-completions.zsh \
+    file://zshrc \
+"
+
+do_install () {
+    install -d ${D}${datadir}/zsh/site-functions
+    install -m 0644 ${WORKDIR}/tedge-completions.zsh ${D}${datadir}/zsh/site-functions/_tedge
+
+    install -d ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/zshrc ${D}${sysconfdir}
+}
+
+FILES:${PN} += " \
+    ${datadir}/zsh/site-functions/_tedge \
+    ${sysconfdir}/zshrc \
+"

--- a/meta-tedge-common/recipes-tedge/tedge-completions-zsh/tedge-completions-zsh/tedge-completions.zsh
+++ b/meta-tedge-common/recipes-tedge/tedge-completions-zsh/tedge-completions-zsh/tedge-completions.zsh
@@ -1,0 +1,18 @@
+#compdef tedge
+function _clap_dynamic_completer_tedge() {
+    local _CLAP_COMPLETE_INDEX=$(expr $CURRENT - 1)
+    local _CLAP_IFS=$'\n'
+
+    local completions=("${(@f)$( \
+        _CLAP_IFS="$_CLAP_IFS" \
+        _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
+        COMPLETE="zsh" \
+        /usr/bin/tedge -- ${words} 2>/dev/null \
+    )}")
+
+    if [[ -n $completions ]]; then
+        _describe 'values' completions
+    fi
+}
+
+compdef _clap_dynamic_completer_tedge tedge

--- a/meta-tedge-common/recipes-tedge/tedge-completions-zsh/tedge-completions-zsh/zshrc
+++ b/meta-tedge-common/recipes-tedge/tedge-completions-zsh/tedge-completions-zsh/zshrc
@@ -1,0 +1,3 @@
+export PROMPT='%n@%m:%1~# '
+autoload -Uz compinit; compinit;
+bindkey -e


### PR DESCRIPTION
Add tab completion recipes for the upcoming thin-edge.io 1.5.0 release and change the default login shell to zsh