### PR TITLE
fix(scarthgap): image and ci fixes

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -7,6 +7,7 @@ jobs:
     if: github.repository_owner == 'thin-edge'
     env:
       PR_BRANCH: updater-${{github.ref_name}}
+      TARGET_BRANCH: ${{github.ref_name}}
     steps:
       - uses: actions/checkout@v4
 
@@ -47,7 +48,7 @@ jobs:
           git config --global user.email "info@thin-edge.io"
           git config --global user.name "Versioneer"
           git checkout -b "$PR_BRANCH"
-          git commit -am "Update ${{github.ref_name}} branch"
+          git commit -am "Update $TARGET_BRANCH branch"
           git push --set-upstream origin "$PR_BRANCH"
           gh repo set-default ${{github.repository}}
-          gh pr create --base "${{github.ref_name}}" --title "chore($PR_BRANCH): Update version/s" --body "Update version/s for the $PR_BRANCH branch"
+          gh pr create --base "$TARGET_BRANCH" --title "chore($TARGET_BRANCH): Update version/s" --body "Update version/s for the $TARGET_BRANCH branch"

--- a/kas/projects/tedge-bin-rauc.lock.yaml
+++ b/kas/projects/tedge-bin-rauc.lock.yaml
@@ -2,15 +2,15 @@ header:
   version: 14
 overrides:
   repos:
-    poky:
-      commit: bab0f9f62af9af580744948dd3240f648a99879a
-    meta-raspberrypi:
-      commit: 3b27c95c163a042f8056066ec3d27edfcc42da7f
     meta-openembedded:
       commit: e92d0173a80ea7592c866618ef5293203c50544c
+    meta-raspberrypi:
+      commit: 3b27c95c163a042f8056066ec3d27edfcc42da7f
     meta-rauc:
       commit: a0f4a8b9986954239850b9d4256c003c91e6b931
     meta-rauc-community:
       commit: 935ea34c32fcdc70b5f48a7f6a6a32b1af65081d
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221
+    poky:
+      commit: 9c63e0c9646c61663e8cfc6b4c75865cd0cd3b34

--- a/kas/projects/tedge-mender-qemu.lock.yaml
+++ b/kas/projects/tedge-mender-qemu.lock.yaml
@@ -2,15 +2,15 @@ header:
   version: 14
 overrides:
   repos:
-    poky:
-      commit: bab0f9f62af9af580744948dd3240f648a99879a
-    meta-openembedded:
-      commit: e92d0173a80ea7592c866618ef5293203c50544c
-    meta-mender:
-      commit: 0d393c2267a92091f975eb932338c07109f5f5fd
     meta-lts-mixins-rust:
-      commit: 65b35821c8e39b13b20f0413c315d0c8f1a64a11
+      commit: 39e6082deb5d982f18ccdba5ef4124b1aaa54e85
     meta-lts-mixins-u-boot:
       commit: 66ceeebd047d7fdfc8668b300319a76da8ae257d
+    meta-mender:
+      commit: 0d393c2267a92091f975eb932338c07109f5f5fd
+    meta-openembedded:
+      commit: e92d0173a80ea7592c866618ef5293203c50544c
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221
+    poky:
+      commit: 9c63e0c9646c61663e8cfc6b4c75865cd0cd3b34

--- a/kas/projects/tedge-mender-tpm2.lock.yaml
+++ b/kas/projects/tedge-mender-tpm2.lock.yaml
@@ -4,14 +4,18 @@ overrides:
   repos:
     meta-lts-mixins-rust:
       commit: 39e6082deb5d982f18ccdba5ef4124b1aaa54e85
+    meta-lts-mixins-u-boot:
+      commit: 66ceeebd047d7fdfc8668b300319a76da8ae257d
+    meta-mender:
+      commit: 0d393c2267a92091f975eb932338c07109f5f5fd
+    meta-mender-community:
+      commit: f4b23faf474241d9030c6fca08d5b58440b48c6d
     meta-openembedded:
       commit: e92d0173a80ea7592c866618ef5293203c50544c
     meta-raspberrypi:
       commit: 3b27c95c163a042f8056066ec3d27edfcc42da7f
-    meta-rauc:
-      commit: a0f4a8b9986954239850b9d4256c003c91e6b931
-    meta-rauc-community:
-      commit: 935ea34c32fcdc70b5f48a7f6a6a32b1af65081d
+    meta-security:
+      commit: bc865c5276c2ab4031229916e8d7c20148dfbac3
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221
     poky:

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -2,19 +2,19 @@ header:
   version: 14
 overrides:
   repos:
-    poky:
-      commit: bab0f9f62af9af580744948dd3240f648a99879a
-    meta-raspberrypi:
-      commit: 3b27c95c163a042f8056066ec3d27edfcc42da7f
-    meta-openembedded:
-      commit: e92d0173a80ea7592c866618ef5293203c50544c
+    meta-lts-mixins-rust:
+      commit: 39e6082deb5d982f18ccdba5ef4124b1aaa54e85
+    meta-lts-mixins-u-boot:
+      commit: 66ceeebd047d7fdfc8668b300319a76da8ae257d
     meta-mender:
       commit: 0d393c2267a92091f975eb932338c07109f5f5fd
     meta-mender-community:
-      commit: 647a8186ac375c804c2500d4db6ab3cd7e2ad26a
-    meta-lts-mixins-rust:
-      commit: 65b35821c8e39b13b20f0413c315d0c8f1a64a11
-    meta-lts-mixins-u-boot:
-      commit: 66ceeebd047d7fdfc8668b300319a76da8ae257d
+      commit: f4b23faf474241d9030c6fca08d5b58440b48c6d
+    meta-openembedded:
+      commit: e92d0173a80ea7592c866618ef5293203c50544c
+    meta-raspberrypi:
+      commit: 3b27c95c163a042f8056066ec3d27edfcc42da7f
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221
+    poky:
+      commit: 9c63e0c9646c61663e8cfc6b4c75865cd0cd3b34

--- a/meta-tedge-common/recipes-core/images/core-image-tedge.bb
+++ b/meta-tedge-common/recipes-core/images/core-image-tedge.bb
@@ -5,6 +5,8 @@ IMAGE_INSTALL:append = " \
     tedge-command-plugin \
     opensc \
     gnutls-bin \
+    zsh \
+    tedge-completions-zsh \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'tedge-bootstrap', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'tedge-sethostname', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'tedge-inventory', '', d)} \
@@ -13,7 +15,9 @@ IMAGE_INSTALL:append = " \
 # Set default shell
 ROOTFS_POSTPROCESS_COMMAND += "change_default_shell;"
 change_default_shell() {
-    [ -f ${IMAGE_ROOTFS}/bin/zsh ] && chsh -R ${IMAGE_ROOTFS} -s /bin/zsh
+    if [ -f ${IMAGE_ROOTFS}/bin/zsh ]; then
+        chsh -R ${IMAGE_ROOTFS} -s /bin/zsh
+    fi
 }
 
 # Create default bashrc file
@@ -21,7 +25,6 @@ ROOTFS_POSTPROCESS_COMMAND += "modify_default_bashrc;"
 modify_default_bashrc() {
     if [ -f ${IMAGE_ROOTFS}/etc/skel/.bashrc ]; then
         echo '[ -f /etc/bash_completion ] && . /etc/bash_completion' >> ${IMAGE_ROOTFS}/etc/skel/.bashrc
+        cp ${IMAGE_ROOTFS}${sysconfdir}/skel/.bashrc ${IMAGE_ROOTFS}${ROOT_HOME}/.bashrc
     fi
-
-    cp ${IMAGE_ROOTFS}${sysconfdir}/skel/.bashrc ${IMAGE_ROOTFS}${ROOT_HOME}/.bashrc
 }

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -42,6 +42,15 @@ get_services_checksum() {
     | jq -r '.data[] | .files[0].checksum_md5'
 }
 
+get_next_minor_version() {
+    # Get the next minor version
+    # e.g. 1.4.2 => 1.5, 1.5.0 => 1.6
+    current_version="$1"
+    major=$(echo "$current_version" | cut -d. -f1)
+    minor=$(echo "$current_version" | cut -d. -f2)
+    next_minor=$((minor + 1))
+    echo "${major}.${next_minor}"
+}
 
 update_version() {
     # Install tooling if missing
@@ -130,6 +139,26 @@ SRCREV_tedge = "$COMMIT_HASH"
 SRCREV_tedge-services = "\${AUTOREV}"
 SRCREV_FORMAT = "tedge"
 S = "\${WORKDIR}/git"
+
+TEDGE_EXCLUDE = "c8y-firmware-plugin"
+
+require tedge.inc
+EOT
+
+    # Set preferred version to the latest official version
+    sed -i 's/PREFERRED_VERSION_tedge ?=.*/PREFERRED_VERSION_tedge ?= "'"$tedge_version"'"/g' kas/config/common.yaml
+
+    # Update the tedge_git.bb to use a fixed version which is the next official version (with git suffix)
+    next_minor_version=$(get_next_minor_version "$tedge_version")
+    tedge_git_bb_file="meta-tedge/recipes-tedge/tedge/tedge_git.bb"
+    echo "Writing bb file for tedge main branch: $tedge_git_bb_file" >&2
+
+    cat <<EOT | tee "$tedge_git_bb_file"
+SRCREV_tedge = "\${AUTOREV}"
+SRCREV_tedge-services = "\${AUTOREV}"
+SRCREV_FORMAT = "tedge"
+S = "\${WORKDIR}/git"
+PV = "${next_minor_version}+git\${SRCPV}"
 
 TEDGE_EXCLUDE = "c8y-firmware-plugin"
 


### PR DESCRIPTION
* Add zsh by default to the image (the change was accidentally left out of the previosu PR)
* Update CI to update the preferred version and the tedge_git recipe to ensure it is automatically updated by the workflow