### PR TITLE
fix(kirkstone): fix package overwrite error between tedge and the collectd

### DIFF
--- a/meta-tedge-common/recipes-core/collectd/collectd_%.bbappend
+++ b/meta-tedge-common/recipes-core/collectd/collectd_%.bbappend
@@ -3,6 +3,6 @@ PACKAGECONFIG[mqtt] = "--with-libmosquitto,--without-libmosquitto,mosquitto"
 
 do_install:append() {
     install -d ${D}${sysconfdir}/collectd/collectd.conf.d
-    # The collectd.conf file is provided by a symlink in the tedge recipe
     rm -f ${D}${sysconfdir}/collectd.conf
+    ln -sf -r ${D}${datadir}/contrib/collectd/collectd.conf ${D}${sysconfdir}/collectd/collectd.conf
 }

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -39,9 +39,8 @@ do_install:append () {
     install -d ${D}${TEDGE_CONFIG_DIR}/sm-plugins
 
     # install collectd for tedge-mapper
-    install -d ${D}${TEDGE_CONFIG_DIR}/contrib/collectd
-    install -m 0644 ${S}/configuration/contrib/collectd/collectd.conf ${D}${TEDGE_CONFIG_DIR}/contrib/collectd
-    ln -sf -r  ${D}${TEDGE_CONFIG_DIR}/contrib/collectd/collectd.conf ${D}${sysconfdir}/collectd.conf
+    install -d ${D}${datadir}/contrib/collectd
+    install -m 0644 ${S}/configuration/contrib/collectd/collectd.conf ${D}${datadir}/contrib/collectd/collectd.conf
 
     # Create symlink for tedge-apt-plugin in `/etc/tedge/sm-plugins`
     install -d ${D}${TEDGE_CONFIG_DIR}/sm-plugins
@@ -78,7 +77,7 @@ do_install:append () {
 
 FILES:${PN} = "\ 
     ${bindir}/* \
-    ${sysconfdir}/collectd.conf \
+    ${datadir}/contrib/collectd/collectd.conf \
     ${TEDGE_CONFIG_SYMLINK} \
     ${TEDGE_CONFIG_DIR} \
     ${TEDGE_CONFIG_DIR}/tedge.toml \


### PR DESCRIPTION
The collectd configuration which is provided by thin-edge.io is not added to the datadir, and then symlinked from the collectd bbappends (from meta-tedge-common).

Previously the deb package class masked the error, however ipk and rpm packages classes were not buildable because of the conflict between collectd and tedge.