### PR TITLE
fix(scarthgap): fix collectd config location and remove explicit runtime dependencies

### DIFF
--- a/kas/config/monitor.yaml
+++ b/kas/config/monitor.yaml
@@ -7,6 +7,6 @@ local_conf_header:
     IMAGE_INSTALL:append = " monit"
 
     # collectd
-    IMAGE_INSTALL:append = " libmosquitto1 libmosquittopp1"
+    IMAGE_INSTALL:append = " libmosquitto1 libmosquittopp1 collectd"
     PACKAGECONFIG:append:pn-collectd = " mqtt"
     SYSTEMD_AUTO_ENABLE:tedge-mapper-collectd = "enable"

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge.inc
@@ -8,7 +8,7 @@ SRC_URI += " \
     file://mosquitto-conf/tedge-mosquitto.conf \
 "
 
-RDEPENDS:${PN} += " mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo collectd"
+RDEPENDS:${PN} += " mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo"
 
 inherit bin_package useradd
 

--- a/meta-tedge-common/recipes-core/collectd/collectd_%.bbappend
+++ b/meta-tedge-common/recipes-core/collectd/collectd_%.bbappend
@@ -4,5 +4,5 @@ PACKAGECONFIG[mqtt] = "--with-libmosquitto,--without-libmosquitto,mosquitto"
 do_install:append() {
     install -d ${D}${sysconfdir}/collectd/collectd.conf.d
     rm -f ${D}${sysconfdir}/collectd.conf
-    ln -sf -r ${D}${datadir}/contrib/collectd/collectd.conf ${D}${sysconfdir}/collectd/collectd.conf
+    ln -sf -r ${D}${datadir}/contrib/collectd/collectd.conf ${D}${sysconfdir}/collectd.conf
 }

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -16,7 +16,7 @@ LICENSE = "Apache-2.0"
 
 inherit cargo-tedge useradd
 
-RDEPENDS:${PN} = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-p11-server mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo collectd"
+RDEPENDS:${PN} = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-p11-server mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo"
 
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM:${PN} = "--system --gid 950 tedge"


### PR DESCRIPTION
Fix the collectd configuration path, and remove the runtime dependencies as collectd is an optional component.