### PR TITLE
feat(scarthgap): add tedge-core project example with minimal dependencies

### DIFF
--- a/kas/config/minimal.yaml
+++ b/kas/config/minimal.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+bblayers_conf_header:
+  meta-minimal: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+
+local_conf_header:
+  meta-minimal: |
+
+    # Change/remove if you don't need these settings
+    PACKAGE_CLASSES ?= "package_ipk"
+    EXTRA_IMAGE_FEATURES ?= "debug-tweaks ssh-server-dropbear"
+
+    # systemd is recommended
+    INIT_MANAGER ?= "systemd"
+
+    # install all tedge components
+    IMAGE_INSTALL:append = " sudo tedge"
+
+    # preferred thin-edge.io version
+    # Use "1.5%" if you want to use the latest from the main branch
+    PREFERRED_VERSION_tedge ?= "1.5.1"
+
+    # Enable/Disable services by using "enable" or "disable"
+    SYSTEMD_AUTO_ENABLE:mosquitto = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-agent = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-aws = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-az = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-c8y = "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-p11-server = "disable"
+
+    # Disable tedge-mapper-collectd mapper if collectd isn't being installed
+    SYSTEMD_AUTO_ENABLE:tedge-mapper-collectd = "disable"

--- a/kas/projects/tedge-core.lock.yaml
+++ b/kas/projects/tedge-core.lock.yaml
@@ -1,0 +1,10 @@
+header:
+  version: 14
+overrides:
+  repos:
+    poky:
+      commit: fa7dd6d5dacdd71bf9c5bb64e7ac63c44a8c175c
+    meta-openembedded:
+      commit: e92d0173a80ea7592c866618ef5293203c50544c
+    meta-lts-mixins-rust:
+      commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04

--- a/kas/projects/tedge-core.yaml
+++ b/kas/projects/tedge-core.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+  includes:
+    - ../config/minimal.yaml
+
+distro: poky
+target: core-image-base
+
+defaults:
+  repos:
+    branch: scarthgap
+
+repos:
+  poky:
+    url: "https://git.yoctoproject.org/git/poky"
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: "https://git.openembedded.org/meta-openembedded"
+    layers:
+      meta-oe:
+      meta-python:
+      meta-networking:
+      meta-multimedia:
+      meta-filesystems:
+
+  meta-lts-mixins-rust:
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
+    branch: scarthgap/rust
+
+  meta-tedge:
+    path: ../../
+    layers:
+      meta-tedge:
+      meta-tedge-common:

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -147,6 +147,7 @@ EOT
 
     # Set preferred version to the latest official version
     sed -i 's/PREFERRED_VERSION_tedge ?=.*/PREFERRED_VERSION_tedge ?= "'"$tedge_version"'"/g' kas/config/common.yaml
+    sed -i 's/PREFERRED_VERSION_tedge ?=.*/PREFERRED_VERSION_tedge ?= "'"$tedge_version"'"/g' kas/config/minimal.yaml
 
     # Update the tedge_git.bb to use a fixed version which is the next official version (with git suffix)
     next_minor_version=$(get_next_minor_version "$tedge_version")


### PR DESCRIPTION
Add a minimal project example which shows the minimum components needed to just install the tedge components (without all of the extras like bootstrapping, set-hostname etc.)