### PR TITLE
fix(kirkstone): use INIT_MANAGER variable to activate systemd usage

### DIFF
--- a/kas/config/minimal.yaml
+++ b/kas/config/minimal.yaml
@@ -14,7 +14,7 @@ local_conf_header:
     EXTRA_IMAGE_FEATURES ?= "debug-tweaks ssh-server-dropbear"
 
     # systemd is recommended
-    DISTRO_FEATURES:append = " systemd"
+    INIT_MANAGER ?= "systemd"
 
     # install all tedge components
     IMAGE_INSTALL:append = " sudo tedge"


### PR DESCRIPTION
Use `INIT_MANAGER` instead of `DISTRO_FEATURES` to control which init system is used.