### PR TITLE
fix(scarthgap): use mender-uboot feature

### DIFF
--- a/kas/config/mender-qemu.yaml
+++ b/kas/config/mender-qemu.yaml
@@ -10,3 +10,4 @@ local_conf_header:
     IMAGE_FSTYPES:remove = " rpi-sdimg wic.bz2 wic.bmap"
     SDIMG_ROOTFS_TYPE = "ext4"
     MENDER_BOOT_PART_SIZE_MB = "64"
+    MENDER_FEATURES_ENABLE:append = " mender-uboot"

--- a/kas/config/mender-raspberrypi.yaml
+++ b/kas/config/mender-raspberrypi.yaml
@@ -12,6 +12,7 @@ local_conf_header:
     IMAGE_FSTYPES:append = " sdimg.bz2"
     IMAGE_FSTYPES:remove = " rpi-sdimg wic.bz2 wic.bmap"
     SDIMG_ROOTFS_TYPE = "ext4"
+    MENDER_FEATURES_ENABLE:append = " mender-uboot"
 
     MENDER_STORAGE_TOTAL_SIZE_MB ?= "4096"
     MENDER_BOOT_PART_SIZE_MB ?= "64"

--- a/kas/projects/tedge-bin-rauc.lock.yaml
+++ b/kas/projects/tedge-bin-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     poky:
-      commit: 9b0e95db584602a13e46ed86b73930506b13e4a9
+      commit: 7500a08bd1eb77421364b661afc63d4042a6aa8c
     meta-raspberrypi:
       commit: bce7b3acd2e0d9d127fcb57eae4a512bd7e7924a
     meta-openembedded:

--- a/kas/projects/tedge-core.lock.yaml
+++ b/kas/projects/tedge-core.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     poky:
-      commit: 9b0e95db584602a13e46ed86b73930506b13e4a9
+      commit: 7500a08bd1eb77421364b661afc63d4042a6aa8c
     meta-openembedded:
       commit: 491671faee11ea131feab5a3a451d1a01deb2ab1
     meta-lts-mixins-rust:

--- a/kas/projects/tedge-mender-qemu.lock.yaml
+++ b/kas/projects/tedge-mender-qemu.lock.yaml
@@ -12,7 +12,5 @@ overrides:
       commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
-    meta-lts-mixins-u-boot:
-      commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221

--- a/kas/projects/tedge-mender-qemu.lock.yaml
+++ b/kas/projects/tedge-mender-qemu.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     poky:
-      commit: 9b0e95db584602a13e46ed86b73930506b13e4a9
+      commit: 7500a08bd1eb77421364b661afc63d4042a6aa8c
     meta-openembedded:
       commit: 491671faee11ea131feab5a3a451d1a01deb2ab1
     meta-mender:
@@ -13,6 +13,6 @@ overrides:
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
     meta-lts-mixins-u-boot:
-      commit: 66ceeebd047d7fdfc8668b300319a76da8ae257d
+      commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221

--- a/kas/projects/tedge-mender-qemu.yaml
+++ b/kas/projects/tedge-mender-qemu.yaml
@@ -61,9 +61,5 @@ repos:
     url: "https://github.com/thin-edge/meta-lts-mixins.git"
     branch: scarthgap/go
 
-  meta-lts-mixins-u-boot:
-    url: "https://git.yoctoproject.org/meta-lts-mixins"
-    branch: scarthgap/u-boot
-
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"

--- a/kas/projects/tedge-mender-tpm2.lock.yaml
+++ b/kas/projects/tedge-mender-tpm2.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     poky:
-      commit: 9b0e95db584602a13e46ed86b73930506b13e4a9
+      commit: 7500a08bd1eb77421364b661afc63d4042a6aa8c
     meta-raspberrypi:
       commit: bce7b3acd2e0d9d127fcb57eae4a512bd7e7924a
     meta-openembedded:
@@ -19,6 +19,6 @@ overrides:
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
     meta-lts-mixins-u-boot:
-      commit: 66ceeebd047d7fdfc8668b300319a76da8ae257d
+      commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221

--- a/kas/projects/tedge-mender-tpm2.lock.yaml
+++ b/kas/projects/tedge-mender-tpm2.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     poky:
-      commit: 7500a08bd1eb77421364b661afc63d4042a6aa8c
+      commit: b8f8125f05e8ece078ba6bf01eebb2900cf2f9bf
     meta-raspberrypi:
       commit: bce7b3acd2e0d9d127fcb57eae4a512bd7e7924a
     meta-openembedded:
@@ -13,12 +13,10 @@ overrides:
     meta-mender:
       commit: 0d393c2267a92091f975eb932338c07109f5f5fd
     meta-mender-community:
-      commit: 313bffde1176b06e6074488cad103bc46b610cbf
+      commit: 1a45f70dc5983454a7822002883546cde27bae7c
     meta-lts-mixins-rust:
       commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
-    meta-lts-mixins-u-boot:
-      commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221

--- a/kas/projects/tedge-mender-tpm2.yaml
+++ b/kas/projects/tedge-mender-tpm2.yaml
@@ -78,10 +78,6 @@ repos:
   meta-lts-mixins-go:
     url: "https://github.com/thin-edge/meta-lts-mixins.git"
     branch: scarthgap/go
-
-  meta-lts-mixins-u-boot:
-    url: "https://git.yoctoproject.org/meta-lts-mixins"
-    branch: scarthgap/u-boot
   
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     poky:
-      commit: 9b0e95db584602a13e46ed86b73930506b13e4a9
+      commit: 7500a08bd1eb77421364b661afc63d4042a6aa8c
     meta-raspberrypi:
       commit: bce7b3acd2e0d9d127fcb57eae4a512bd7e7924a
     meta-openembedded:
@@ -17,6 +17,6 @@ overrides:
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
     meta-lts-mixins-u-boot:
-      commit: 66ceeebd047d7fdfc8668b300319a76da8ae257d
+      commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -11,12 +11,10 @@ overrides:
     meta-mender:
       commit: 0d393c2267a92091f975eb932338c07109f5f5fd
     meta-mender-community:
-      commit: 313bffde1176b06e6074488cad103bc46b610cbf
+      commit: 1a45f70dc5983454a7822002883546cde27bae7c
     meta-lts-mixins-rust:
       commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
-    meta-lts-mixins-u-boot:
-      commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221

--- a/kas/projects/tedge-mender.yaml
+++ b/kas/projects/tedge-mender.yaml
@@ -69,10 +69,6 @@ repos:
   meta-lts-mixins-go:
     url: "https://github.com/thin-edge/meta-lts-mixins.git"
     branch: scarthgap/go
-
-  meta-lts-mixins-u-boot:
-    url: "https://git.yoctoproject.org/meta-lts-mixins"
-    branch: scarthgap/u-boot
   
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"

--- a/kas/projects/tedge-rauc.lock.yaml
+++ b/kas/projects/tedge-rauc.lock.yaml
@@ -3,7 +3,7 @@ header:
 overrides:
   repos:
     poky:
-      commit: 9b0e95db584602a13e46ed86b73930506b13e4a9
+      commit: 7500a08bd1eb77421364b661afc63d4042a6aa8c
     meta-raspberrypi:
       commit: bce7b3acd2e0d9d127fcb57eae4a512bd7e7924a
     meta-openembedded:


### PR DESCRIPTION
As #260 highlighted, the latest scarthgap build failed due to u-boot. This is a try to fix the issue.

The first commit 53eb3a01dfa067b5daf98b08a1eeea977dc655f2 is cherry-picked from #259.
The second commit is the actual change. 

Confirmed that RPi4 booted with this change.