### PR TITLE
feat: decrease priority of the tedge_git recipe to prefer the last official release

### DIFF
--- a/meta-tedge/recipes-tedge/tedge/tedge_git.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_git.bb
@@ -3,6 +3,7 @@ SRCREV_tedge-services = "${AUTOREV}"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 PV = "1.6+git${SRCPV}"
+DEFAULT_PREFERENCE = "-1"
 
 TEDGE_EXCLUDE = "c8y-firmware-plugin"
 


### PR DESCRIPTION
Use Yocto best practices to prefer a fixed release over the autorev version to avoid accidentally changing versions across building from the same source (if users don't use the `PREFERRED_VERSION_tedge` variable).