### PR TITLE
chore(scarthgap): use meta-lts u-boot layer due to mender build issue without it

### DIFF
--- a/kas/projects/tedge-bin-rauc.lock.yaml
+++ b/kas/projects/tedge-bin-rauc.lock.yaml
@@ -3,16 +3,16 @@ header:
 overrides:
   repos:
     poky:
-      commit: b8f8125f05e8ece078ba6bf01eebb2900cf2f9bf
+      commit: ae2d52758fc2fcb0ed996aa234430464ebf4b310
     meta-raspberrypi:
-      commit: 1091bde25e9ebaea33114edb85e4aee931d105f3
+      commit: 48452445d779b0f69bf1ead12b3850d50eb8920d
     meta-openembedded:
-      commit: 727811eaf256b88fd135be99559f2cbf14c82fce
+      commit: e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943
     meta-rauc:
       commit: a0f4a8b9986954239850b9d4256c003c91e6b931
     meta-rauc-community:
       commit: 935ea34c32fcdc70b5f48a7f6a6a32b1af65081d
     meta-virtualization:
-      commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221
+      commit: a5449c0c50aa07d02186f548fe6bb6c1ce8823dc
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13

--- a/kas/projects/tedge-core.lock.yaml
+++ b/kas/projects/tedge-core.lock.yaml
@@ -3,8 +3,8 @@ header:
 overrides:
   repos:
     poky:
-      commit: b8f8125f05e8ece078ba6bf01eebb2900cf2f9bf
+      commit: ae2d52758fc2fcb0ed996aa234430464ebf4b310
     meta-openembedded:
-      commit: 727811eaf256b88fd135be99559f2cbf14c82fce
+      commit: e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943
     meta-lts-mixins-rust:
       commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04

--- a/kas/projects/tedge-mender-qemu.lock.yaml
+++ b/kas/projects/tedge-mender-qemu.lock.yaml
@@ -3,9 +3,9 @@ header:
 overrides:
   repos:
     poky:
-      commit: b8f8125f05e8ece078ba6bf01eebb2900cf2f9bf
+      commit: ae2d52758fc2fcb0ed996aa234430464ebf4b310
     meta-openembedded:
-      commit: 727811eaf256b88fd135be99559f2cbf14c82fce
+      commit: e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943
     meta-mender:
       commit: 0d393c2267a92091f975eb932338c07109f5f5fd
     meta-lts-mixins-rust:
@@ -13,4 +13,4 @@ overrides:
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
     meta-virtualization:
-      commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221
+      commit: a5449c0c50aa07d02186f548fe6bb6c1ce8823dc

--- a/kas/projects/tedge-mender-tpm2.lock.yaml
+++ b/kas/projects/tedge-mender-tpm2.lock.yaml
@@ -18,5 +18,7 @@ overrides:
       commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
+    meta-lts-mixins-u-boot:
+      commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221

--- a/kas/projects/tedge-mender-tpm2.lock.yaml
+++ b/kas/projects/tedge-mender-tpm2.lock.yaml
@@ -3,17 +3,17 @@ header:
 overrides:
   repos:
     poky:
-      commit: b8f8125f05e8ece078ba6bf01eebb2900cf2f9bf
+      commit: ae2d52758fc2fcb0ed996aa234430464ebf4b310
     meta-raspberrypi:
-      commit: 1091bde25e9ebaea33114edb85e4aee931d105f3
+      commit: 48452445d779b0f69bf1ead12b3850d50eb8920d
     meta-openembedded:
-      commit: 727811eaf256b88fd135be99559f2cbf14c82fce
+      commit: e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943
     meta-security:
       commit: bc865c5276c2ab4031229916e8d7c20148dfbac3
     meta-mender:
       commit: 0d393c2267a92091f975eb932338c07109f5f5fd
     meta-mender-community:
-      commit: 1a45f70dc5983454a7822002883546cde27bae7c
+      commit: 69e18c5aef75f5bafa693e5c1fe8a0448f4d337b
     meta-lts-mixins-rust:
       commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
     meta-lts-mixins-go:
@@ -21,4 +21,4 @@ overrides:
     meta-lts-mixins-u-boot:
       commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
-      commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221
+      commit: a5449c0c50aa07d02186f548fe6bb6c1ce8823dc

--- a/kas/projects/tedge-mender-tpm2.yaml
+++ b/kas/projects/tedge-mender-tpm2.yaml
@@ -78,6 +78,10 @@ repos:
   meta-lts-mixins-go:
     url: "https://github.com/thin-edge/meta-lts-mixins.git"
     branch: scarthgap/go
-  
+
+  meta-lts-mixins-u-boot:
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
+    branch: scarthgap/u-boot
+
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -16,5 +16,7 @@ overrides:
       commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
+    meta-lts-mixins-u-boot:
+      commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
       commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -3,15 +3,15 @@ header:
 overrides:
   repos:
     poky:
-      commit: b8f8125f05e8ece078ba6bf01eebb2900cf2f9bf
+      commit: ae2d52758fc2fcb0ed996aa234430464ebf4b310
     meta-raspberrypi:
-      commit: 1091bde25e9ebaea33114edb85e4aee931d105f3
+      commit: 48452445d779b0f69bf1ead12b3850d50eb8920d
     meta-openembedded:
-      commit: 727811eaf256b88fd135be99559f2cbf14c82fce
+      commit: e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943
     meta-mender:
       commit: 0d393c2267a92091f975eb932338c07109f5f5fd
     meta-mender-community:
-      commit: 1a45f70dc5983454a7822002883546cde27bae7c
+      commit: 69e18c5aef75f5bafa693e5c1fe8a0448f4d337b
     meta-lts-mixins-rust:
       commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
     meta-lts-mixins-go:
@@ -19,4 +19,4 @@ overrides:
     meta-lts-mixins-u-boot:
       commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
-      commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221
+      commit: a5449c0c50aa07d02186f548fe6bb6c1ce8823dc

--- a/kas/projects/tedge-mender.yaml
+++ b/kas/projects/tedge-mender.yaml
@@ -69,6 +69,10 @@ repos:
   meta-lts-mixins-go:
     url: "https://github.com/thin-edge/meta-lts-mixins.git"
     branch: scarthgap/go
-  
+
+  meta-lts-mixins-u-boot:
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
+    branch: scarthgap/u-boot
+
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"

--- a/kas/projects/tedge-rauc.lock.yaml
+++ b/kas/projects/tedge-rauc.lock.yaml
@@ -3,11 +3,11 @@ header:
 overrides:
   repos:
     poky:
-      commit: b8f8125f05e8ece078ba6bf01eebb2900cf2f9bf
+      commit: ae2d52758fc2fcb0ed996aa234430464ebf4b310
     meta-raspberrypi:
-      commit: 1091bde25e9ebaea33114edb85e4aee931d105f3
+      commit: 48452445d779b0f69bf1ead12b3850d50eb8920d
     meta-openembedded:
-      commit: 727811eaf256b88fd135be99559f2cbf14c82fce
+      commit: e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943
     meta-rauc:
       commit: a0f4a8b9986954239850b9d4256c003c91e6b931
     meta-rauc-community:
@@ -17,4 +17,4 @@ overrides:
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
     meta-virtualization:
-      commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221
+      commit: a5449c0c50aa07d02186f548fe6bb6c1ce8823dc


### PR DESCRIPTION
After checking to see what the meta-mender-community layer used for raspberry pi examples, it showed that they also rely on the meta-lts scarthgap/u-boot layer, and since the latest commits weren't building properly, the layer was added back in