### PR TITLE
chore(scarthgap): align to yocto best practices

### DIFF
--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -16,8 +16,8 @@ local_conf_header:
     TEDGE_CONFIG_DIR = "/etc/tedge"
 
     # preferred thin-edge.io version
-    # Use "1.5%" if you want to use the latest from the main branch
-    PREFERRED_VERSION_tedge ?= "1.5.1"
+    # Use "1.X%" if you want to use the latest from the main branch
+    #PREFERRED_VERSION_tedge ?= "1.6.0"
 
     # Add /etc/buildinfo file with information about build
     INHERIT += "image-buildinfo"

--- a/kas/config/minimal.yaml
+++ b/kas/config/minimal.yaml
@@ -20,8 +20,8 @@ local_conf_header:
     IMAGE_INSTALL:append = " sudo tedge"
 
     # preferred thin-edge.io version
-    # Use "1.5%" if you want to use the latest from the main branch
-    PREFERRED_VERSION_tedge ?= "1.5.1"
+    # Use "1.X%" if you want to use the latest from the main branch
+    #PREFERRED_VERSION_tedge ?= "1.6.0"
 
     # Enable/Disable services by using "enable" or "disable"
     SYSTEMD_AUTO_ENABLE:mosquitto = "disable"

--- a/kas/projects/tedge-mender-tpm2.lock.yaml
+++ b/kas/projects/tedge-mender-tpm2.lock.yaml
@@ -13,7 +13,7 @@ overrides:
     meta-mender:
       commit: 0d393c2267a92091f975eb932338c07109f5f5fd
     meta-mender-community:
-      commit: 69e18c5aef75f5bafa693e5c1fe8a0448f4d337b
+      commit: 8e57f49fa0aefed3c0a3701e96a6edae88a2f79c
     meta-lts-mixins-rust:
       commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
     meta-lts-mixins-go:

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -11,7 +11,7 @@ overrides:
     meta-mender:
       commit: 0d393c2267a92091f975eb932338c07109f5f5fd
     meta-mender-community:
-      commit: 69e18c5aef75f5bafa693e5c1fe8a0448f4d337b
+      commit: 8e57f49fa0aefed3c0a3701e96a6edae88a2f79c
     meta-lts-mixins-rust:
       commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
     meta-lts-mixins-go:

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.6.0.bb
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.6.0.bb
@@ -1,0 +1,17 @@
+# Architecture variables
+ARCH_REPO_CHANNEL = "release"
+ARCH_VERSION = "1.6.0"
+SRC_URI[aarch64.md5sum] = "00bf610ef8e6be6dc4c524c411347d76"
+SRC_URI[armv6.md5sum] = "029db8ba6e45116966e566db2d3512a9"
+SRC_URI[armv7.md5sum] = "13856e166ba08f64eb637da406f8a4db"
+SRC_URI[x86_64.md5sum] = "5cc482caad1183ccbb2266aeda964803"
+SRC_URI[riscv64.md5sum] = "e9872ebc993238f82cecd60be9e4cb8a"
+
+# Init manager variables
+INIT_REPO_CHANNEL = "community"
+INIT_VERSION = "0.7.4"
+SRC_URI[openrc.md5sum] = "eda14cc61d3c1be5d7fd8ff9543fad07"
+SRC_URI[systemd.md5sum] = "2220a0eecd01da450176e60db2fef895"
+SRC_URI[sysvinit.md5sum] = "fc7a3913b556afd503717e4d457e65a8"
+
+require tedge.inc

--- a/meta-tedge-common/recipes-tedge/tedge-inventory/tedge-inventory_0.5.0.bb
+++ b/meta-tedge-common/recipes-tedge/tedge-inventory/tedge-inventory_0.5.0.bb
@@ -1,5 +1,5 @@
 SRC_URI += "git://git@github.com/thin-edge/tedge-inventory-plugin.git;protocol=https;branch=main"
-SRCREV = "${AUTOREV}"
+SRCREV = "eb8c2b56d5c5852b363a2b65d546324541c23212"
 
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10" 
@@ -8,7 +8,7 @@ inherit systemd allarch features_check
 
 REQUIRED_DISTRO_FEATURES = "systemd"
 
-PV = "0.3.1+git${SRCPV}"
+PV = "0.5.0"
 
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.0.0.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.0.0.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "9cf69044581fc4046d52009f909b41af40124a95"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "17b8e2e98ce2bc9f36be21701e557e959a686968"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.0.1.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.0.1.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "64def4e4c5ed8e600d3ab090725ad3af57f1579f"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "17b8e2e98ce2bc9f36be21701e557e959a686968"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.1.0.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.1.0.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "ea66825c0f83d48a1fe8c38acce8765fe172b22c"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "17b8e2e98ce2bc9f36be21701e557e959a686968"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.1.1.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.1.1.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "8bd6a3aba02560950b51901f5ff6ec855f53ee81"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "17b8e2e98ce2bc9f36be21701e557e959a686968"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.2.0.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.2.0.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "bbfef48d4beb6bb23a8828c6c953078f3272dfe1"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "17b8e2e98ce2bc9f36be21701e557e959a686968"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.3.0.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.3.0.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "61fdb06b3407c4d744cd4a8cec94df2b7eab97de"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "17b8e2e98ce2bc9f36be21701e557e959a686968"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.3.1.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.3.1.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "0866b9b9d7571f1479571d0600a42923a9b2980f"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "17b8e2e98ce2bc9f36be21701e557e959a686968"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.4.1.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.4.1.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "b48c19c148d9f71cda434b0f8b76c0a115fd5fb2"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "17b8e2e98ce2bc9f36be21701e557e959a686968"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.4.2.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.4.2.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "510146764ce1ad306c75634215854699a44d4870"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "17b8e2e98ce2bc9f36be21701e557e959a686968"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.5.0.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.5.0.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "e38b6fb3800352252985b54f33a001dffc6f074e"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "f495b82f0002be81a7778483003139a223a508a1"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.5.1.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.5.1.bb
@@ -1,5 +1,5 @@
 SRCREV_tedge = "1ec3eed5cc6b6cd9282195cb205bde3635ecfece"
-SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_tedge-services = "f495b82f0002be81a7778483003139a223a508a1"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
 

--- a/meta-tedge/recipes-tedge/tedge/tedge_1.6.0.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_1.6.0.bb
@@ -1,0 +1,8 @@
+SRCREV_tedge = "a93d3fbcaf04c0a62cf4a1453309d72017c105f5"
+SRCREV_tedge-services = "f495b82f0002be81a7778483003139a223a508a1"
+SRCREV_FORMAT = "tedge"
+S = "${WORKDIR}/git"
+
+TEDGE_EXCLUDE = "c8y-firmware-plugin"
+
+require tedge.inc

--- a/meta-tedge/recipes-tedge/tedge/tedge_git.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_git.bb
@@ -2,7 +2,8 @@ SRCREV_tedge = "${AUTOREV}"
 SRCREV_tedge-services = "${AUTOREV}"
 SRCREV_FORMAT = "tedge"
 S = "${WORKDIR}/git"
-PV = "1.6+git${SRCPV}"
+PV = "1.7+git${SRCPV}"
+DEFAULT_PREFERENCE = "-1"
 
 TEDGE_EXCLUDE = "c8y-firmware-plugin"
 

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -129,6 +129,7 @@ EOT
 
     TAG=$(echo "$MATCHING_TAG" | cut -f1)
     COMMIT_HASH=$(echo "$MATCHING_TAG" | cut -f2)
+    TEDGE_SERVICES_COMMIT_HASH=$(gh api /repos/thin-edge/tedge-services/commits | jq -r '.[0].sha')
 
     echo "Found tag: tag=$TAG, commit=$COMMIT_HASH" >&2
 
@@ -136,7 +137,7 @@ EOT
     tedge_bb_file="meta-tedge/recipes-tedge/tedge/tedge_${tedge_version}.bb"
     cat << EOT | tee "$tedge_bb_file" >&2
 SRCREV_tedge = "$COMMIT_HASH"
-SRCREV_tedge-services = "\${AUTOREV}"
+SRCREV_tedge-services = "$TEDGE_SERVICES_COMMIT_HASH"
 SRCREV_FORMAT = "tedge"
 S = "\${WORKDIR}/git"
 
@@ -145,9 +146,13 @@ TEDGE_EXCLUDE = "c8y-firmware-plugin"
 require tedge.inc
 EOT
 
+    SED="sed"
+    if command -v gsed >/dev/null 2>&1; then
+        SED="gsed"
+    fi
     # Set preferred version to the latest official version
-    sed -i 's/PREFERRED_VERSION_tedge ?=.*/PREFERRED_VERSION_tedge ?= "'"$tedge_version"'"/g' kas/config/common.yaml
-    sed -i 's/PREFERRED_VERSION_tedge ?=.*/PREFERRED_VERSION_tedge ?= "'"$tedge_version"'"/g' kas/config/minimal.yaml
+    $SED -i 's/PREFERRED_VERSION_tedge ?=.*/PREFERRED_VERSION_tedge ?= "'"$tedge_version"'"/g' kas/config/common.yaml
+    $SED -i 's/PREFERRED_VERSION_tedge ?=.*/PREFERRED_VERSION_tedge ?= "'"$tedge_version"'"/g' kas/config/minimal.yaml
 
     # Update the tedge_git.bb to use a fixed version which is the next official version (with git suffix)
     next_minor_version=$(get_next_minor_version "$tedge_version")

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -160,6 +160,7 @@ SRCREV_tedge-services = "\${AUTOREV}"
 SRCREV_FORMAT = "tedge"
 S = "\${WORKDIR}/git"
 PV = "${next_minor_version}+git\${SRCPV}"
+DEFAULT_PREFERENCE = "-1"
 
 TEDGE_EXCLUDE = "c8y-firmware-plugin"
 


### PR DESCRIPTION
Various improvements (non-functional change) to align with Yocto best practices which includes reproducible builds.

* use fixed version for tedge-inventory
* chore: update lock files
* add tedge 1.6.0 version
* set tedge-service repo to latest commit
* avoid using explicitly set tedge version
* use fixed version for tedge-services instead of using AUTOREV