### PR TITLE
feat(kirkstone): add rugix integration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,3 +94,5 @@ jobs:
             kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}*.${{ matrix.image_ext }}
             kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}*.${{ matrix.update_ext }}
             kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}*.${{ matrix.manifest_ext }}
+            kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}*.spdx.tar.zst
+            kas/build/tmp/deploy/images/${{ matrix.machine }}/${{ matrix.image_name }}*${{ matrix.machine }}*.cve.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,7 @@ jobs:
         project:
           - tedge-rauc
           - tedge-mender
+          - tedge-rugix
         machine:
           - raspberrypi
           - raspberrypi2
@@ -58,6 +59,19 @@ jobs:
             image_ext: "sdimg.bz2"
             update_ext: "mender"
             manifest_ext: "manifest"
+
+          - project: tedge-rugix
+            image_name: core-image-tedge-rugix
+            image_ext: "wic.bz2"
+            update_ext: "rugixb"
+            manifest_ext: "manifest"
+        
+        exclude:
+          - project: tedge-rugix
+            machine: raspberrypi
+
+          - project: tedge-rugix
+            machine: raspberrypi2
 
     steps:
       - name: Checkout

--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -15,6 +15,10 @@ local_conf_header:
     INIT_MANAGER="systemd"
     TEDGE_CONFIG_DIR = "/etc/tedge"
 
+    # enable CVE checks
+    CVE_CHECK_MANIFEST_JSON_SUFFIX ?= "cve.json"
+    INHERIT += "cve-check"
+
     # preferred thin-edge.io version
     # Use "1.X%" if you want to use the latest from the main branch
     #PREFERRED_VERSION_tedge ?= "1.6.0"

--- a/kas/config/rugix-raspberrypi.yaml
+++ b/kas/config/rugix-raspberrypi.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  rugix-raspberrypi: |
+    IMAGE_INSTALL:append = " kernel-image kernel-modules kernel-devicetree"
+
+    IMAGE_FSTYPES = " tar.bz2 ext4 wic.bz2 wic.bmap"
+    SDIMG_ROOTFS_TYPE = "ext4"
+    WKS_FILE = "sdimage-rugix-rpi-tryboot.wks.in"

--- a/kas/config/rugix.yaml
+++ b/kas/config/rugix.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+local_conf_header:
+  rugix: |
+    DISTRO_FEATURES:append = " rugix "
+    IMAGE_INSTALL:append = " rugix-ctrl rugix-bootstrapping-conf "

--- a/kas/projects/tedge-rugix.lock.yaml
+++ b/kas/projects/tedge-rugix.lock.yaml
@@ -1,0 +1,18 @@
+header:
+  version: 14
+overrides:
+  repos:
+    poky:
+      commit: ae2d52758fc2fcb0ed996aa234430464ebf4b310
+    meta-raspberrypi:
+      commit: 48452445d779b0f69bf1ead12b3850d50eb8920d
+    meta-openembedded:
+      commit: e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943
+    meta-rugix:
+      commit: 4dc0fcf84572dac3fdc25ddbb2cce57492ab7f8b
+    meta-lts-mixins-rust:
+      commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
+    meta-lts-mixins-go:
+      commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
+    meta-virtualization:
+      commit: a5449c0c50aa07d02186f548fe6bb6c1ce8823dc

--- a/kas/projects/tedge-rugix.lock.yaml
+++ b/kas/projects/tedge-rugix.lock.yaml
@@ -2,17 +2,17 @@ header:
   version: 14
 overrides:
   repos:
-    poky:
-      commit: ae2d52758fc2fcb0ed996aa234430464ebf4b310
-    meta-raspberrypi:
-      commit: 48452445d779b0f69bf1ead12b3850d50eb8920d
-    meta-openembedded:
-      commit: e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943
-    meta-rugix:
-      commit: 4dc0fcf84572dac3fdc25ddbb2cce57492ab7f8b
-    meta-lts-mixins-rust:
-      commit: a8046d5ec53b1856169ac795aa87cb0d5db84c04
     meta-lts-mixins-go:
-      commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
+      commit: 4e092daf1e920a44fb51d6df67cbddc9bc399e33
+    meta-lts-mixins-rust:
+      commit: dcc60f3115a8133c4013ce36cb6fe0969c07d6f5
+    meta-openembedded:
+      commit: 06fc0278f10d630838d703dde707bbf0e2999873
+    meta-raspberrypi:
+      commit: 39e5dfd9cb8f11eda189d0beb62d27c83fc57e75
+    meta-rugix:
+      commit: 22e60ef3aeb07f630af163a5ad1aef42ac8e97e6
     meta-virtualization:
-      commit: a5449c0c50aa07d02186f548fe6bb6c1ce8823dc
+      commit: 3e4dba95e6b5f5f68d0b3a5899b106c89da59428
+    poky:
+      commit: f4219fb3e291eaffbb475b91ad4a8c4772a9c7d3

--- a/kas/projects/tedge-rugix.yaml
+++ b/kas/projects/tedge-rugix.yaml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+  includes:
+    - ../config/common.yaml
+    - ../config/raspberrypi.yaml
+    - ../config/rugix.yaml
+    - ../config/rugix-raspberrypi.yaml
+    - ../config/network.yaml
+    - ../config/monitor.yaml
+    - ../config/package-management.yaml
+    - ../config/tedge-docker.yaml
+    - ../config/tedge-nodered.yaml
+
+machine: raspberrypi-armv8
+distro: poky
+target: rugix-update-bundle
+
+env:
+  IMAGE_VERSION: ""
+  IMAGE_VERSION_SUFFIX: "_123123"
+  RUGIX_BUNDLE_NAME: "core-image-tedge-rugix-${MACHINE}${IMAGE_VERSION_SUFFIX}"
+
+defaults:
+  repos:
+    branch: kirkstone
+
+repos:
+  poky:
+    url: "https://git.yoctoproject.org/git/poky"
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-raspberrypi:
+    url: "https://github.com/agherzan/meta-raspberrypi.git"
+
+  meta-openembedded:
+    url: "https://git.openembedded.org/meta-openembedded"
+    layers:
+      meta-oe:
+      meta-python:
+      meta-networking:
+      meta-multimedia:
+      meta-filesystems:
+
+  meta-rugix:
+    url: "https://github.com/silitics/meta-rugix.git"
+    branch: main
+    layers:
+      meta-rugix-core:
+      meta-rugix-rpi-tryboot:
+
+  meta-tedge:
+    path: ../../
+    layers:
+      meta-tedge:
+      meta-tedge-common:
+      meta-tedge-rugix:
+      meta-tedge-extras:
+      meta-raspberrypi:
+
+  meta-lts-mixins-rust:
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
+    branch: kirkstone/rust
+
+  meta-lts-mixins-go:
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
+    branch: kirkstone/go
+
+  meta-virtualization:
+    url: "https://git.yoctoproject.org/meta-virtualization"

--- a/meta-tedge-common/recipes-core/images/core-image-tedge.bb
+++ b/meta-tedge-common/recipes-core/images/core-image-tedge.bb
@@ -5,6 +5,8 @@ IMAGE_INSTALL:append = " \
     tedge-command-plugin \
     opensc \
     gnutls-bin \
+    vnstat \
+    less \
     zsh \
     tedge-completions-zsh \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'tedge-bootstrap', '', d)} \

--- a/meta-tedge-common/recipes-support/xdelta3/xdelta3_%.bbappend
+++ b/meta-tedge-common/recipes-support/xdelta3/xdelta3_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append = " lzma"

--- a/meta-tedge-rugix/conf/layer.conf
+++ b/meta-tedge-rugix/conf/layer.conf
@@ -1,0 +1,15 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-tedge-rugix"
+BBFILE_PATTERN_meta-tedge-rugix = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-tedge-rugix = "6"
+LAYERDEPENDS_meta-tedge-rugix = "meta-tedge-common"
+
+LICENSE_PATH += "${LAYERDIR}/"
+
+LAYERSERIES_COMPAT_meta-tedge-rugix = "kirkstone"

--- a/meta-tedge-rugix/recipes-core/images/core-image-tedge-rugix.bb
+++ b/meta-tedge-rugix/recipes-core/images/core-image-tedge-rugix.bb
@@ -1,0 +1,82 @@
+require recipes-core/images/core-image-tedge.bb
+
+IMAGE_INSTALL:append = " \
+    tedge-firmware-rugix \
+    firmware-auto-rollback \
+    tedge-inventory-rugix \
+"
+
+# Copy all files from IMAGE_BOOT_FILES into the ROOTFS
+ROOTFS_POSTPROCESS_COMMAND += " copy_boot_files_into_rootfs; "
+
+python copy_boot_files_into_rootfs() {
+    import os
+    import shutil
+
+    # From https://github.com/openembedded/openembedded-core/blob/master/meta/lib/oe/bootfiles.py#L15
+    # Replace once it is available in the respective yocto versions
+    def get_boot_files(deploy_dir, boot_files):
+        import re
+        import os
+        from glob import glob
+
+        if boot_files is None:
+            return None
+
+        # list of tuples (src_name, dst_name)
+        deploy_files = []
+        for src_entry in re.findall(r'[\w;\-\./\*]+', boot_files):
+            if ';' in src_entry:
+                dst_entry = tuple(src_entry.split(';'))
+                if not dst_entry[0] or not dst_entry[1]:
+                    raise ValueError('Malformed boot file entry: %s' % src_entry)
+            else:
+                dst_entry = (src_entry, src_entry)
+
+            deploy_files.append(dst_entry)
+
+        install_files = []
+        for deploy_entry in deploy_files:
+            src, dst = deploy_entry
+            if '*' in src:
+                # by default install files under their basename
+                entry_name_fn = os.path.basename
+                if dst != src:
+                    # unless a target name was given, then treat name
+                    # as a directory and append a basename
+                    entry_name_fn = lambda name: \
+                                    os.path.join(dst,
+                                                os.path.basename(name))
+
+                srcs = glob(os.path.join(deploy_dir, src))
+
+                for entry in srcs:
+                    src = os.path.relpath(entry, deploy_dir)
+                    entry_dst_name = entry_name_fn(entry)
+                    install_files.append((src, entry_dst_name))
+            else:
+                install_files.append((src, dst))
+
+        return install_files
+
+    d = locals()['d']
+    deploy_dir = d.getVar('DEPLOY_DIR_IMAGE')
+    image_rootfs = d.getVar('IMAGE_ROOTFS')
+    boot_dir = os.path.join(image_rootfs, 'boot')
+    image_boot_files = d.getVar('IMAGE_BOOT_FILES')
+
+    # remove the existing /boot directory
+    shutil.rmtree(boot_dir)
+
+    install_files = get_boot_files(deploy_dir, image_boot_files)
+
+    os.makedirs(boot_dir, exist_ok=True)
+
+    for (src, dst) in install_files:
+        dst_path = os.path.join(boot_dir, dst)
+        src_path = os.path.join(deploy_dir, src)
+        os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+
+        print(f"Copying boot file into rootfs. src={src_path}, dst={dst_path}")
+        shutil.copy2(src_path, dst_path)
+}

--- a/meta-tedge-rugix/recipes-tedge/firmware-auto-rollback/firmware-auto-rollback.bb
+++ b/meta-tedge-rugix/recipes-tedge/firmware-auto-rollback/firmware-auto-rollback.bb
@@ -1,0 +1,29 @@
+LICENSE = "CLOSED"
+
+SRC_URI += " \
+    file://firmware-auto-rollback \
+    file://firmware-auto-rollback.timer \
+    file://firmware-auto-rollback.service \
+"
+
+inherit ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}
+
+RDEPENDS:${PN} += " rugix-ctrl jq"
+
+do_install () {
+    # auto rollback service incase if new agent is corrupt (only rely on tooling which is definitely there)
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${systemd_system_unitdir}
+        install -D -m 0755 ${WORKDIR}/firmware-auto-rollback ${D}${bindir}/firmware-auto-rollback
+        install -D -m 0644 ${WORKDIR}/firmware-auto-rollback.service -t ${D}${systemd_system_unitdir}
+        install -D -m 0644 ${WORKDIR}/firmware-auto-rollback.timer -t ${D}${systemd_system_unitdir}
+    fi
+}
+
+SYSTEMD_SERVICE:${PN} = "firmware-auto-rollback.timer"
+
+FILES:${PN} += " \
+    ${bindir}/firmware-auto-rollback \
+    ${systemd_system_unitdir}/firmware-auto-rollback.service \
+    ${systemd_system_unitdir}/firmware-auto-rollback.timer \
+"

--- a/meta-tedge-rugix/recipes-tedge/firmware-auto-rollback/firmware-auto-rollback/firmware-auto-rollback
+++ b/meta-tedge-rugix/recipes-tedge/firmware-auto-rollback/firmware-auto-rollback/firmware-auto-rollback
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+SUDO=""
+if command -V sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+fi
+
+BOOT_ACTIVE=$($SUDO rugix-ctrl system info --json | jq -r '.boot.activeGroup' | tr '[:lower:]' '[:upper:]')
+BOOT_DEFAULT=$($SUDO rugix-ctrl system info --json | jq -r '.boot.defaultGroup' | tr '[:lower:]' '[:upper:]')
+
+if [ -n "$BOOT_ACTIVE" ] && [ -n "$BOOT_DEFAULT" ] && [ "$BOOT_ACTIVE" = "$BOOT_DEFAULT" ]; then
+    echo "Already on default partition. Nothing to rollback to. active=$BOOT_ACTIVE, default=$BOOT_DEFAULT" >&2
+    exit 0
+fi
+
+echo "Rebooting into default partition. active=$BOOT_ACTIVE, default=$BOOT_DEFAULT"
+$SUDO reboot
+exit 0

--- a/meta-tedge-rugix/recipes-tedge/firmware-auto-rollback/firmware-auto-rollback/firmware-auto-rollback.service
+++ b/meta-tedge-rugix/recipes-tedge/firmware-auto-rollback/firmware-auto-rollback/firmware-auto-rollback.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Rollback to default partition if this service has not been disabled yet
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/firmware-auto-rollback
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-tedge-rugix/recipes-tedge/firmware-auto-rollback/firmware-auto-rollback/firmware-auto-rollback.timer
+++ b/meta-tedge-rugix/recipes-tedge/firmware-auto-rollback/firmware-auto-rollback/firmware-auto-rollback.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=rugix auto rollback
+
+[Timer]
+OnBootSec=1800s
+
+[Install]
+WantedBy=timers.target

--- a/meta-tedge-rugix/recipes-tedge/rugix-bundle/rugix-update-bundle.bb
+++ b/meta-tedge-rugix/recipes-tedge/rugix-bundle/rugix-update-bundle.bb
@@ -1,0 +1,9 @@
+inherit rugix-bundle
+
+RUGIX_BUNDLE_PAYLOADS = "boot system"
+
+RUGIX_PAYLOAD_boot[image] = "core-image-tedge-rugix"
+RUGIX_PAYLOAD_boot[partition] = "2"
+
+RUGIX_PAYLOAD_system[image] = "core-image-tedge-rugix"
+RUGIX_PAYLOAD_system[partition] = "4"

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix.bb
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix.bb
@@ -1,0 +1,83 @@
+LICENSE = "CLOSED"
+
+SRC_URI += " \
+    file://rugix_workflow.sh \
+    file://system.toml \
+    file://firmware_update.rugix.toml \
+    file://tedge-firmware-rugix \
+    file://persist.conf \
+    file://state.toml \
+    file://state-persistence.toml \
+    file://state-persistence-systemd.toml \
+    file://hooks/pre-commit/00-transfer-state \
+    file://hooks/pre-commit/01-time-sync \
+    file://hooks/pre-commit/10-tedge-health \
+"
+
+DEPENDS = "tedge mosquitto"
+RDEPENDS:${PN} += " tedge rugix-ctrl xdelta3 curl"
+
+TEDGE_CONFIG_DIR ?= "/etc/tedge"
+
+do_install () {
+    bbnote "tedge recipe config: TEDGE_CONFIG_DIR=${TEDGE_CONFIG_DIR}"
+
+    # Add firmware worfklow and script
+    install -d "${D}${bindir}"
+    install -m 0755 "${WORKDIR}/rugix_workflow.sh" "${D}${bindir}"
+
+    install -d "${D}${datadir}/tedge-workflows"
+    install -d "${D}${TEDGE_CONFIG_DIR}/operations"
+    install -m 0644 "${WORKDIR}/firmware_update.rugix.toml" "${D}${datadir}/tedge-workflows/"
+
+    # Use a symlink to allow updating the workflow across updates
+    ln --relative -s "${D}${datadir}/tedge-workflows/firmware_update.rugix.toml" "${D}${TEDGE_CONFIG_DIR}/operations/firmware_update.toml"
+
+    # Allow sudo access
+    install -d -m 0750 "${D}/etc/sudoers.d"
+    install -m 0644 "${WORKDIR}/tedge-firmware-rugix" "${D}${sysconfdir}/sudoers.d/"
+
+    install -d ${D}${TEDGE_CONFIG_DIR}
+    install -m 0644 ${WORKDIR}/system.toml ${D}${TEDGE_CONFIG_DIR}/
+
+    # mosquitto setup
+    install -d "${D}/var/lib/mosquitto"
+    install -d "${D}${TEDGE_CONFIG_DIR}/mosquitto-conf/"
+    install -m 0644 "${WORKDIR}/persist.conf" "${D}${TEDGE_CONFIG_DIR}/mosquitto-conf/"
+
+    # FIXME: Check if there is a better place to do this
+    if [ -d "${D}/var/lib/mosquitto" ]; then
+        chown -R mosquitto:mosquitto "${D}/var/lib/mosquitto"
+    fi
+
+    # Configure state persistence options
+    install -m 0755 -d ${D}${sysconfdir}/rugix
+    install -D -m 0755 ${WORKDIR}/state.toml ${D}${sysconfdir}/rugix/
+
+    # Store files/directories which should be persisted in the overlay
+    install -m 0755 -d ${D}${sysconfdir}/rugix/state
+    install -D -m 0644 ${WORKDIR}/state-persistence.toml ${D}${sysconfdir}/rugix/state/
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -D -m 0644 ${WORKDIR}/state-persistence-systemd.toml ${D}${sysconfdir}/rugix/state/
+    fi
+
+    # Add system-hooks
+    # https://oss.silitics.com/rugix/docs/ctrl/hooks#system-update-hooks
+    install -m 0755 -d ${D}${sysconfdir}/rugix/hooks/system-commit/pre-commit
+    install -D -m 0755 "${WORKDIR}/hooks/pre-commit/"* ${D}${sysconfdir}/rugix/hooks/system-commit/pre-commit/
+}
+
+SYSTEMD_SERVICE:${PN} = "firmware-auto-rollback.timer"
+
+FILES:${PN} += " \
+    ${bindir}/rugix_workflow.sh \
+    ${TEDGE_CONFIG_DIR}/operations/system.toml \
+    ${TEDGE_CONFIG_DIR}/operations/firmware_update.toml \
+    ${datadir}/tedge-workflows/firmware_update.rugix.toml \
+    ${sysconfdir}/sudoers.d/tedge-firmware-rugix \
+    ${sysconfdir}/image_version \
+    ${sysconfdir}/rugix/state.toml \
+    ${sysconfdir}/rugix/state/state-persistence.toml \
+    ${sysconfdir}/rugix/hooks/system-commit/pre-commit \
+"

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/firmware_update.rugix.toml
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/firmware_update.rugix.toml
@@ -1,0 +1,73 @@
+#:schema https://gist.githubusercontent.com/reubenmiller/4e28e8403fe0c54b7461ac7d1d6838c2/raw/56bb3339be8e251e5cbdade7a6cdb40aa9992126/tedge.workflow.json
+operation = "firmware_update"
+on_error = "failed"
+
+[init]
+action = "proceed"
+on_success = "scheduled"
+
+[scheduled]
+action = "proceed"
+on_success = "executing"
+
+[executing]
+script = "/usr/bin/rugix_workflow.sh ${.payload.status}"
+on_success = "download"
+on_error = { status = "failed", reason = "Refusing to start update as the wrong partition is active" }
+
+[download]
+script = "/usr/bin/rugix_workflow.sh ${.payload.status} --url ${.payload.remoteUrl}"
+on_success = "install"
+on_error = { status = "failed", reason = "Failed to download image"}
+
+[install]
+script = "/usr/bin/rugix_workflow.sh ${.payload.status} --url ${.payload.url}"
+on_success = "restart"
+on_error = { status = "failed", reason = "Failed to install image"}
+
+[restart]
+operation = "restart"
+on_exec = "await_restart"
+
+[await_restart]
+action = "await-operation-completion"
+on_success = "restarted"
+on_error = { status = "failed_restart", reason = "Failed to restart device" }
+
+[restarted]
+script = "/usr/bin/rugix_workflow.sh ${.payload.status}"
+on_success = "verify"
+on_error = { status = "rollback_restart", reason = "Unexpected error during restarted check. Rolling back"}
+
+[failed_restart]
+script = "/usr/bin/rugix_workflow.sh failed_restart"
+on_success = { status = "failed", reason = "Device failed to restart" }
+
+[verify]
+script = "/usr/bin/rugix_workflow.sh ${.payload.status} --firmware-name ${.payload.name} --firmware-version ${.payload.version}"
+on_exit.0 = { status = "commit" }
+on_exit.4 = { status = "rollback_restart", reason = "Verification failed. Rolling back to default partition" }
+on_exit._ = { status = "failed", reason = "Verification failed, no rollback necessary" }
+
+[commit]
+script = "/usr/bin/rugix_workflow.sh ${.payload.status}"
+on_success = "successful"
+on_error = { status = "rollback_restart", reason = "Commit failed. Rolling back to default partition" }
+
+[rollback_restart]
+operation = "restart"
+on_exec = "await_rollback_restart"
+
+[await_rollback_restart]
+action = "await-operation-completion"
+on_success = "rollback_successful"
+
+[rollback_successful]
+script = "/usr/bin/rugix_workflow.sh ${.payload.status}"
+on_success = { status = "failed", reason = "Firmware update failed, but the rollback to the default partition was successful" }
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/hooks/pre-commit/00-transfer-state
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/hooks/pre-commit/00-transfer-state
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# State migration which is required when using overlays, as the overlay will prevent the image from
+# updating state if it has been overridden by the user at some point in time.
+#
+
+set -e
+
+OK=0
+
+log() { echo "$*" >&2; }
+
+if [ ! -L /etc/tedge/operations/c8y/c8y_Command ]; then
+    log "Replacing legacy c8y-command-plugin files with tedge-command-plugin"
+    rm -f /etc/tedge/operations/c8y/c8y_Command
+    cp -a /run/rugix/mounts/system/etc/tedge/operations/shell_execute.toml /etc/tedge/operations/shell_execute.toml
+    cp -a /run/rugix/mounts/system/etc/tedge/operations/c8y/c8y_Command.template /etc/tedge/operations/c8y/
+    ln -f /etc/tedge/operations/c8y/c8y_Command.template /etc/tedge/operations/c8y/c8y_Command
+else
+    log "Legacy c8y-command-plugin files have already been migrated"
+fi
+
+exit "${OK}"

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/hooks/pre-commit/01-time-sync
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/hooks/pre-commit/01-time-sync
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Wait for network to be ready but don't block if still not available as the mender commit
+# might be used to restore network connectivity.
+#
+
+set -e
+
+OK=0
+
+log() {
+    echo "$*" >&2
+}
+
+attempt=0
+max_attempts=10
+
+# Network ready: 0 = no, 1 = yes
+ready=0
+log "Waiting for network to be ready, and time to be synced"
+
+while [ "$attempt" -lt "$max_attempts" ]; do
+    TIME_IN_SYNC=$(timedatectl | awk '/System clock synchronized/{print $NF}')
+    case "${TIME_IN_SYNC}" in
+        yes)
+            ready=1
+            break
+            ;;
+    esac
+    attempt=$((attempt + 1))
+    log "Network not ready yet (attempt: $attempt from $max_attempts)"
+    sleep 30
+done
+
+# Duration can only be based on uptime since the device's clock might not be synced yet, so 'date' will not be monotonic
+duration=$(awk '{print $1}' /proc/uptime)
+
+log "Network: ready=$ready (after ${duration}s)"
+if [ "$ready" = "1" ]; then
+    log "Network is ready after ${duration}s (from startup)"
+else
+    # Don't fail, as the downstream checks might still work
+    log "WARNING: System time is still not in sync but continuing anyway"
+fi
+
+exit ${OK}

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/hooks/pre-commit/10-tedge-health
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/hooks/pre-commit/10-tedge-health
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Check thin-edge.io connection to the cloud
+# Whilst the connection test may be lost due to normal events (e.g. switching mobile networks)
+# however since we can't know if the network loss is due the update or not, then take the
+# safer option of assuming it is due to the update and perform a rollback.
+#
+set -e
+
+log() {
+    echo "$(date +%Y-%m-%dT%H:%M:%S) $*"
+}
+
+# TODO: Support cloud profiles and look for all enabled mappers, not just the standard names
+MAPPERS="c8y az aws"
+
+is_mapper_connected() {
+    CLOUD_MAPPER="$1"
+
+    if [ -n "$(tedge config get "${CLOUD_MAPPER}.url" 2>/dev/null)" ]; then
+
+        # Use a reconnect as it will also recreate the bridge config (in case it has changed)
+        sudo tedge reconnect "$CLOUD_MAPPER" || return 1
+
+        # re-run test as reconnect can silently fail
+        tedge connect "$CLOUD_MAPPER" --test || return 1
+
+    else
+        # If the configuration is not configured, then treat the device as healthy
+        echo "Mapper is not configured: $CLOUD_MAPPER" >&2
+        return 0
+    fi
+}
+
+is_healthy() {
+    # 0=ok, 1=not_ok
+    ok=0
+    for name in $MAPPERS; do
+        is_mapper_connected "$name" || ok=1
+    done
+    return "$ok"
+}
+
+main() {
+    NOT_OK=1
+    RETRY_DELAY=30
+
+    for _i in $(seq 1 10); do
+        if is_healthy; then
+            NOT_OK=0
+            break
+        fi
+        log "Waiting $RETRY_DELAY seconds before checking the health again"
+        sleep "$RETRY_DELAY"
+    done
+
+    exit "$NOT_OK"
+}
+
+main

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/persist.conf
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/persist.conf
@@ -1,0 +1,2 @@
+persistence true
+persistence_location /data/mosquitto/

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/rugix_workflow.sh
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/rugix_workflow.sh
@@ -1,0 +1,440 @@
+#!/bin/sh
+set -e
+FIRMWARE_NAME=
+FIRMWARE_VERSION=
+FIRMWARE_URL=
+MANUAL_DOWNLOAD=0
+STREAM_DOWNLOAD=auto
+NETRC_FILE="${NETRC_FILE:-"/etc/tedge/.netrc"}"
+CHECK_META_INFO=0
+
+# Enable indexes whilst using dynamic or static delta updates as the first delta update
+DELTA_UPDATE_METHOD=${DELTA_UPDATE_METHOD:-casync}
+
+# Exit codes
+OK=0
+FAILED=1
+REQUEST_RESTART=4
+
+# Use temp directory so that the file can't accidentally persist across partitions
+# thus always booting into the spare partition
+REBOOT_SPARE_REQUEST=/tmp/.reboot_spare
+
+# Detect if sudo should be used or not. It will be used if it is found
+SUDO=""
+if command -V sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+fi
+
+_WORKDIR=$(pwd)
+
+# Change to a directory which is readable otherwise rugix-ctrl can have problems reading the mounts
+cd /tmp || cd /
+
+BOOT_ACTIVE=$($SUDO rugix-ctrl system info --json | jq -r '.boot.activeGroup' | tr '[:lower:]' '[:upper:]')
+BOOT_DEFAULT=$($SUDO rugix-ctrl system info --json | jq -r '.boot.defaultGroup' | tr '[:lower:]' '[:upper:]')
+
+if [ "$BOOT_ACTIVE" = "A" ]; then
+    BOOT_SPARE=B
+else
+    BOOT_SPARE=A
+fi
+
+ACTION="$1"
+shift
+
+log() {
+    msg="$(date +%Y-%m-%dT%H:%M:%S) [current=$ACTION] $*"
+    echo "$msg" >&2
+
+    # publish to pub for better resolution
+    tedge mqtt pub -q 2 te/device/main///e/firmware_update "{\"text\":\"Firmware Workflow: [$ACTION] $*\",\"state\":\"$ACTION\",\"partition\":\"$BOOT_ACTIVE\"}"
+    sleep 1
+}
+
+local_log() {
+    # Only log locally and don't push to the cloud
+    msg="$(date +%Y-%m-%dT%H:%M:%S) [current=$ACTION] $*"
+    echo "$msg" >&2
+}
+
+update_state() {
+    echo ":::begin-tedge:::"
+    echo "$1"
+    echo ":::end-tedge:::"
+    sleep 1
+}
+
+set_reason() {
+    reason="$1"
+    message=$(printf '{"reason":"%s"}' "$reason")
+    update_state "$message"
+}
+
+#
+# main
+#
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --firmware-name)
+            FIRMWARE_NAME="$2"
+            shift
+            ;;
+        --firmware-version)
+            FIRMWARE_VERSION="$2"
+            shift
+            ;;
+        --url)
+            FIRMWARE_URL="$2"
+            shift
+            ;;
+    esac
+    shift
+done
+
+wait_for_network() {
+    #
+    # Wait for network to be ready but don't block if still not available as the commit
+    # might be used to restore network connectivity.
+    #
+    attempt=0
+    max_attempts=10
+    # Network ready: 0 = no, 1 = yes
+    ready=0
+    local_log "Waiting for network to be ready, and time to be synced"
+
+    while [ "$attempt" -lt "$max_attempts" ]; do
+        # TIME_SYNC_ACTIVE=$(timedatectl | grep NTP | awk '{print $NF}')
+        TIME_IN_SYNC=$(timedatectl | awk '/System clock synchronized/{print $NF}')
+        case "${TIME_IN_SYNC}" in
+            yes)
+                ready=1
+                break
+                ;;
+        esac
+        attempt=$((attempt + 1))
+        local_log "Network not ready yet (attempt: $attempt from $max_attempts)"
+        sleep 30
+    done
+
+    # Duration can only be based on uptime since the device's clock might not be synced yet, so 'date' will not be monotonic
+    duration=$(awk '{print $1}' /proc/uptime)
+
+    local_log "Network: ready=$ready (after ${duration}s)"
+    if [ "$ready" = "1" ]; then
+        log "Network is ready after ${duration}s (from startup)"
+        return 0
+    fi
+
+    # Don't send cloud message if it is not ready
+    return 1
+}
+
+executing() {
+    if [ "$BOOT_ACTIVE" != "$BOOT_DEFAULT" ]; then
+        set_reason "Refusing to install update as the current (active) partition is not the default partition. This indicates that you may be in the middle of an update. Please reboot to switch to the default partition"
+        exit "$FAILED"
+    fi
+    log "Starting firmware update. Current partition is $BOOT_ACTIVE, so update will be applied to $BOOT_SPARE"
+}
+
+set_streaming_setting() {
+    if [ "$STREAM_DOWNLOAD" != "auto" ]; then
+        return
+    fi
+
+    url="$1"
+    case "$url" in
+        */inventory/binaries/*)
+            # disable streaming as rugix can use the c8y local proxy service
+            STREAM_DOWNLOAD=0
+            ;;
+        *)
+            STREAM_DOWNLOAD=1
+            ;;
+    esac
+}
+
+download() {
+    url="$1"
+
+    #
+    # Change url to a local url using the c8y proxy
+    #
+    url_hosted_in_c8y=0
+    case "$url" in
+        https://*/inventory/binaries/*)
+            # Cumulocity URL, use the c8y auth proxy service
+            partial_path=$(echo "$url" | sed 's|https://[^/]*/||g')
+            c8y_proxy_host=$(tedge config get c8y.proxy.client.host)
+            c8y_proxy_port=$(tedge config get c8y.proxy.client.port)
+            tedge_url="http://${c8y_proxy_host}:${c8y_proxy_port}/c8y/$partial_path"
+            url_hosted_in_c8y=1
+            ;;
+        http://*|https://*)
+            # External URL, pass it untouched
+            # NOTE: If a service required authorization, then this would be the place to add it
+            # For example some blob stores support signed URLS
+            partial_path=$(echo "$url" | sed 's|https://[^/]*/||g')
+            tedge_url="$url"
+            ;;
+        *)
+            # Assume url is actually a file and just go to the next state
+            update_state "$(printf '{"url":"%s"}\n' "$url")"
+            return "$OK"
+            ;;
+    esac
+
+    if [ "$MANUAL_DOWNLOAD" = 1 ]; then
+        TEDGE_DATA=$(tedge config get data.path)
+
+        # Removing any older files to ensure space for next file to download
+        # Note: busy box does not support the -delete flag
+        find "$TEDGE_DATA" -name "*.firmware" -exec rm {} \;
+
+        last_part=$(echo "$partial_path" | rev | cut -d/ -f1 | rev)
+        local_file="$TEDGE_DATA/${last_part}.firmware"
+        log "Manually downloading artifact from $tedge_url and saving to $local_file"
+
+        download_file "$tedge_url" "$local_file"
+        log "Downloaded file from: $tedge_url"
+        update_state "$(printf '{"url":"%s"}\n' "$local_file")"
+    else
+        log "Replacing url with a tedge url: $tedge_url"
+        update_state "$(printf '{"url":"%s"}\n' "$tedge_url")"
+    fi
+}
+
+download_file() {
+    url="$1"
+
+    # Output file. Defaults to stdout, "-"
+    output_file="-"
+    if [ $# -gt 1 ]; then
+        output_file="$2"
+    fi
+
+    # Use curl so that netrc files can be supported
+    case "$url" in
+        *zip)
+            # decompress using bsdtar as it supports unzipping via streaming
+            # so that we don't have to download the file, unzip, then pass it on
+            if [ "$output_file" != "-" ]; then
+                curl -sfL \
+                    --connect-timeout 30 \
+                    --retry 5 \
+                    --retry-delay 0 \
+                    --netrc-file "$NETRC_FILE" \
+                    --netrc-optional \
+                    "$url" \
+                | bsdtar -x -O > "$output_file"
+            else
+                # stream to stdout
+                curl -sfL \
+                    --connect-timeout 30 \
+                    --retry 5 \
+                    --retry-delay 0 \
+                    --netrc-file "$NETRC_FILE" \
+                    --netrc-optional \
+                    "$url" \
+                | bsdtar -x -O
+            fi
+            ;;
+        *)
+            curl -sfL \
+                --connect-timeout 30 \
+                --retry 5 \
+                --retry-delay 0 \
+                --netrc-file "$NETRC_FILE" \
+                --netrc-optional \
+                -o "$output_file" \
+                -C - \
+                "$url"
+            ;;
+    esac
+}
+
+install() {
+    url="$1"
+
+    set_streaming_setting "$url"
+
+    # TODO: Is this required, or can the update provide additional information about what
+    # type of update it is and if the indexes are required or not
+    case "$DELTA_UPDATE_METHOD" in
+        casync)
+            # Note: dynamic updates aren't supported when streaming downloads as rugix needs
+            # do send the HTTP request to download the relevant portions of the binary
+            if [ "$STREAM_DOWNLOAD" = 0 ]; then
+                # Note: It is possible that the need for this may be removed in future rugix versions
+                local_log "Preparing index for dynamic delta updates"
+                if [ "$BOOT_ACTIVE" = "a" ]; then
+                    $SUDO rugix-ctrl slots create-index boot-a casync-64 sha512-256
+                    $SUDO rugix-ctrl slots create-index system-a casync-64 sha512-256
+                else
+                    $SUDO rugix-ctrl slots create-index boot-b casync-64 sha512-256
+                    $SUDO rugix-ctrl slots create-index system-b casync-64 sha512-256
+                fi
+            fi
+            ;;
+        xdelta)
+            # TODO: How to check if the slot can be used or not for delta updates
+            # See https://oss.silitics.com/rugix/docs/next/ctrl/delta-updates/#static-delta-updates
+            ;;
+    esac
+
+    set +e
+    case "$url" in
+        http://*|https://*)
+            if [ "$STREAM_DOWNLOAD" = 1 ]; then
+                log "Downloading and streaming image to rugix"
+                download_file "$url" | $SUDO rugix-ctrl update install --reboot no -
+            else
+                log "Downloading image using rugix"
+                $SUDO rugix-ctrl update install --reboot no "$url"
+            fi
+            ;;
+        *)
+            # It is a file
+            log "Installing local image to rugix"
+            $SUDO rugix-ctrl update install --reboot no "$url"
+            ;;
+    esac
+    EXIT_CODE=$?
+    set -e
+
+    case "$EXIT_CODE" in
+        0)
+            log "OK, RESTART required"
+            ;;
+        *)
+            log "ERROR. Unexpected return code. code=$EXIT_CODE"
+            ;;
+    esac
+
+    # Create mark file which is used by the restart state to reboot into the spare partition
+    touch "$REBOOT_SPARE_REQUEST" ||:
+    exit "$EXIT_CODE"
+}
+
+restart() {
+    # NOTE: This function should not be called in the script directly but rather via the system.toml
+    if [ -f "$REBOOT_SPARE_REQUEST" ]; then
+        rm -f "$REBOOT_SPARE_REQUEST" ||:
+
+        message=$(printf '{"text":"Rebooting into spare partition (%s -> %s)","partition":"%s"}' "$BOOT_ACTIVE" "$BOOT_SPARE" "$BOOT_ACTIVE")
+        tedge mqtt pub -q 1 "te/device/main///e/reboot_spare" "$message" ||:
+        sleep 5
+        $SUDO rugix-ctrl system reboot --spare
+    else
+        message=$(printf '{"text":"Rebooting into default partition (%s -> %s)","partition":"%s"}' "$BOOT_ACTIVE" "$BOOT_DEFAULT" "$BOOT_ACTIVE")
+        tedge mqtt pub -q 1 "te/device/main///e/reboot_default" "$message" ||:
+        sleep 5
+        $SUDO rugix-ctrl system reboot
+    fi
+    exit "$OK"
+}
+
+verify() {
+    log "Checking device health"
+
+    # Rollback just in case if the partitions could not be read, so we can't confirm which partition we are on
+    if [ -z "$BOOT_ACTIVE" ] || [ -z "$BOOT_DEFAULT" ]; then
+        set_reason "Could not read partition information so rolling back to be safe. ACTIVE=$BOOT_ACTIVE, DEFAULT=$BOOT_DEFAULT"
+        exit "$REQUEST_RESTART"
+    fi
+
+    if [ "$BOOT_ACTIVE" = "$BOOT_DEFAULT" ]; then
+        # Don't both to reboot if no partition swap occurred because we are already in the ok partition
+        set_reason "Partition swap did not occur. Reasons could be, corrupt/non-bootable image, someone did a manual rollback or the machine was restarted manually before the health check was run"
+        exit "$FAILED"
+    fi
+
+    # Check that the versions match the expected otherwise people can get
+    # into bad habits of not ensuring the meta information in the operation
+    # does not match the actual image
+    # TODO: Use rugix-ctrl instead of reading the file directly (once the cli supports showing the image info)
+    if [ "$CHECK_META_INFO" = 1 ]; then
+        ARTIFACT_FILE=/etc/rugix/system-build-info.json
+        if [ -f /etc/rugix/system-build-info.json ]; then
+            ACTUAL_NAME=$(jq -r '.name' "$ARTIFACT_FILE")
+            ACTUAL_VERSION=$(jq -r '.release.version // "0.0"' "$ARTIFACT_FILE")
+
+            if [ "$ACTUAL_NAME" != "$FIRMWARE_NAME" ] || [ "$ACTUAL_VERSION" != "$FIRMWARE_VERSION" ]; then
+                DETAILS=$(printf '\n    actual: name=%s, version=%s\n  expected: name=%s, version=%s)' "$$ACTUAL_NAME" "$ACTUAL_VERSION" "$$FIRMWARE_NAME" "$FIRMWARE_VERSION")
+                set_reason "New image name does not match the values from the operation. Please check that the firmware name/version matches the actual image.${DETAILS}"
+                exit "$REQUEST_RESTART"
+            fi
+        fi
+    fi
+}
+
+commit() {
+    log "Executing: rugix-ctrl system commit"
+    set +e
+    $SUDO rugix-ctrl system commit
+    EXIT_CODE=$?
+    set -e
+
+    case "$EXIT_CODE" in
+        0)
+            # Check what the updated default partition is
+            BOOT_DEFAULT=$($SUDO rugix-ctrl system info --json | jq -r '.boot.defaultGroup' | tr '[:lower:]' '[:upper:]')
+
+            log "Commit successful. New default partition is $BOOT_DEFAULT"
+            ;;
+        *)
+            log "rugix-ctrl returned code: $EXIT_CODE. Rolling back to previous partition"
+            ;;
+    esac
+
+    # update inventory scripts after the commit has been changed
+    $SUDO systemctl start tedge-inventory.service || local_log "Failed to run tedge-inventory.service"
+
+    exit "$EXIT_CODE"
+}
+
+rollback_successful() {
+    # TODO: Support cloud profiles and look for all enabled mappers, not just the standard names
+    MAPPERS="c8y az aws"
+    for CLOUD_MAPPER in $MAPPERS; do
+        if [ -n "$(tedge config get "${CLOUD_MAPPER}.url" 2>/dev/null)" ]; then
+            # Use a reconnect as it will also recreate the bridge config
+            log "Reconnecting $CLOUD_MAPPER mapper"
+            if ! $SUDO tedge reconnect "$CLOUD_MAPPER"; then
+                log "WARNING: Failed to reconnect the mapper"
+            fi
+        fi
+    done
+
+    # update inventory scripts after the commit has been changed
+    $SUDO systemctl start tedge-inventory.service || local_log "Failed to run tedge-inventory.service"
+
+    log "Firmware update failed, but the rollback was successful. partition=$BOOT_ACTIVE, default=$BOOT_DEFAULT"
+}
+
+case "$ACTION" in
+    executing) executing; ;;
+    download) download "$FIRMWARE_URL"; ;;
+    install) install "$FIRMWARE_URL"; ;;
+    verify) verify; ;;
+    commit) commit; ;;
+    restart) restart; ;;
+    restarted)
+	    wait_for_network ||:
+        log "Device has been restarted...continuing workflow. partition=$BOOT_ACTIVE, default=$BOOT_DEFAULT"
+        ;;
+    rollback_successful)
+        rollback_successful
+        ;;
+    failed_restart) ;;
+    *)
+        log "Unknown command. This script only accepts: download, install, commit, rollback, rollback_successful, failed_restart"
+        exit "$FAILED"
+        ;;
+esac
+
+# switch back to original directory
+cd "$_WORKDIR" ||:
+
+exit "$OK"

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/state-persistence-systemd.toml
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/state-persistence-systemd.toml
@@ -1,0 +1,2 @@
+[[persist]]
+directory = "/etc/systemd/system/multi-user.target.wants"

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/state-persistence.toml
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/state-persistence.toml
@@ -1,0 +1,22 @@
+#:schema https://raw.githubusercontent.com/silitics/rugix/refs/tags/v0.8.0/schemas/rugix-ctrl-state.schema.json
+
+[[persist]]
+directory = "/etc/tedge"
+
+[[persist]]
+directory = "/data"
+
+[[persist]]
+directory = "/etc/NetworkManager/system-connections"
+
+[[persist]]
+directory = "/etc/dropbear"
+
+[[persist]]
+file = "/etc/hostname"
+
+[[persist]]
+directory = "/root"
+
+[[persist]]
+directory = "/var/lib/vnstat"

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/state.toml
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/state.toml
@@ -1,0 +1,1 @@
+overlay = "persist"

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/system.toml
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/system.toml
@@ -1,0 +1,2 @@
+[system]
+reboot = ["/usr/bin/rugix_workflow.sh", "restart"]

--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/tedge-firmware-rugix
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/tedge-firmware-rugix
@@ -1,0 +1,1 @@
+tedge  ALL = (ALL) NOPASSWD: /usr/bin/rugix-ctrl, /usr/bin/rugix_workflow.sh, /usr/bin/systemctl start *

--- a/meta-tedge-rugix/recipes-tedge/tedge-inventory-rugix/tedge-inventory-rugix.bb
+++ b/meta-tedge-rugix/recipes-tedge/tedge-inventory-rugix/tedge-inventory-rugix.bb
@@ -1,0 +1,17 @@
+LICENSE = "CLOSED"
+
+SRC_URI += " \
+    file://rugix-system \ 
+"
+
+DEPENDS = "tedge-inventory"
+RDEPENDS:${PN} += " tedge-inventory rugix-ctrl jq"
+
+do_install () {
+    install -d ${D}${datadir}/tedge-inventory/scripts.d
+    install -m 0755 ${WORKDIR}/rugix-system ${D}${datadir}/tedge-inventory/scripts.d/85_rugix_System
+}
+
+FILES:${PN} += " \
+    ${datadir}/tedge-inventory/scripts.d/85_rugix_System \
+"

--- a/meta-tedge-rugix/recipes-tedge/tedge-inventory-rugix/tedge-inventory-rugix/rugix-system
+++ b/meta-tedge-rugix/recipes-tedge/tedge-inventory-rugix/tedge-inventory-rugix/rugix-system
@@ -1,0 +1,69 @@
+#!/bin/sh
+##################################################
+# Rugix system information
+#
+# Example input format:
+# ```
+# {
+#   "slots": {
+#     "boot-a": {
+#       "active": true,
+#       "hashes": {},
+#       "updatedAt": "2025-07-14T21:05:23.224099988Z"
+#     },
+#     "boot-b": {
+#       "active": false,
+#       "hashes": {},
+#       "updatedAt": "2025-07-14T20:15:01.459841658Z"
+#     },
+#     "system-a": {
+#       "active": true,
+#       "hashes": {
+#         "sha512_256": "sha512-256:f7b953f455c06b515333873de43ee5d69997d997432faf411755b7c4b525e4fa"
+#       },
+#       "size": 2406704640,
+#       "updatedAt": "2025-07-14T21:07:26.922661546Z"
+#     },
+#     "system-b": {
+#       "active": false,
+#       "hashes": {
+#         "sha512_256": "sha512-256:99f64878855be24d5e9a3a1aa64643cf08203c07aa48c79f34c4085eeefb165d"
+#       },
+#       "size": 2406704640,
+#       "updatedAt": "2025-07-14T20:16:59.002372104Z"
+#     }
+#   },
+#   "boot": {
+#     "bootFlow": "tryboot",
+#     "activeGroup": "a",
+#     "defaultGroup": "a",
+#     "groups": {
+#       "a": {},
+#       "b": {}
+#     }
+#   }
+# }
+# ```
+##################################################
+set -e
+
+SUDO=""
+if command -V sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+fi
+
+SYSTEM_INFO=$($SUDO rugix-ctrl system info --json 2>/dev/null)
+
+echo "defaultGroup=$(echo "$SYSTEM_INFO" | jq .boot.defaultGroup)"
+echo "activeGroup=$(echo "$SYSTEM_INFO" | jq .boot.activeGroup)"
+echo "bootFlow=$(echo "$SYSTEM_INFO" | jq .boot.bootFlow)"
+
+# use string due to wider c8y UI support for filtering on strings rather than a boolean
+echo "defaultActive=\"$(echo "$SYSTEM_INFO" | jq '.boot.activeGroup == .boot.defaultGroup')\""
+
+ACTIVE_PARTITION=$(echo "$SYSTEM_INFO" | jq -r .boot.activeGroup)
+ACTIVE_PARTITION_HASH=$(echo "$SYSTEM_INFO" | jq -r '.slots."system-'"${ACTIVE_PARTITION}"'".hashes.sha512_256 // ""' ||:)
+ACTIVE_UPDATED_AT=$(echo "$SYSTEM_INFO" | jq -r '.slots."system-'"${ACTIVE_PARTITION}"'".updatedAt // "-"' ||:)
+
+echo "hash=\"${ACTIVE_PARTITION_HASH}\""
+echo "updatedAt=\"${ACTIVE_UPDATED_AT}\""


### PR DESCRIPTION
Add integration for building images with [Rugix](https://github.com/silitics/rugix) via the [meta-rugix](https://github.com/silitics/meta-rugix/) layer, to provide images which support A/B update and state management using Rugix.

* Support both static and delta updates
* Install vnstat to track bandwidth usage on network adapters
* Add xdelta3 (required for static delta updates)
* Enable cve-check
* Upload sbom and cve-check outputs when building on the CI server

**Notes**

* Only for tryboot enabled RaspberryPi devices, e.g. rpi4 & rpi5. Additional integration for other devices is possible by requires the creation of the u-boot scripts etc.
