### PR TITLE
feat(kirkstone): add a recipe that builds only tedge-p11-server

### DIFF
--- a/kas/config/tedge-p11-server-minimal.yaml
+++ b/kas/config/tedge-p11-server-minimal.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+bblayers_conf_header:
+  meta-tedge-p11-server: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+
+local_conf_header:
+  meta-tedge-p11-server: |
+    # Change/remove if you don't need these settings
+    PACKAGE_CLASSES ?= "package_ipk"
+    EXTRA_IMAGE_FEATURES ?= "debug-tweaks ssh-server-dropbear"
+
+    # systemd is recommended
+    INIT_MANAGER ?= "systemd"
+
+    # install only tedge-p11-server
+    IMAGE_INSTALL:append = " tedge-p11-server"
+
+    # preferred thin-edge.io version
+    # Use "1.X%" if you want to use the latest from the main branch
+    # PREFERRED_VERSION_tedge-p11-server ?= "1.6.0"
+
+    # Enable/Disable services by using "enable" or "disable"
+    SYSTEMD_AUTO_ENABLE:tedge-p11-server = "enable"
+

--- a/kas/projects/tedge-p11-server.lock.yaml
+++ b/kas/projects/tedge-p11-server.lock.yaml
@@ -1,0 +1,10 @@
+header:
+  version: 14
+overrides:
+  repos:
+    poky:
+      commit: f4219fb3e291eaffbb475b91ad4a8c4772a9c7d3
+    meta-openembedded:
+      commit: 06fc0278f10d630838d703dde707bbf0e2999873
+    meta-lts-mixins-rust:
+      commit: 895b8b76de6dea32ba53b86e4db3ec5b9b275f28

--- a/kas/projects/tedge-p11-server.yaml
+++ b/kas/projects/tedge-p11-server.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+  includes:
+    - ../config/tedge-p11-server-minimal.yaml
+
+machine: qemux86-64
+distro: poky
+target: core-image-base
+
+defaults:
+  repos:
+    branch: kirkstone
+
+repos:
+  poky:
+    url: "https://git.yoctoproject.org/git/poky"
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: "https://git.openembedded.org/meta-openembedded"
+    layers:
+      meta-oe:
+      meta-python:
+      meta-networking:
+      meta-multimedia:
+      meta-filesystems:
+
+  meta-lts-mixins-rust:
+    url: "https://git.yoctoproject.org/meta-lts-mixins"
+    branch: kirkstone/rust
+
+  meta-tedge:
+    path: ../../
+    layers:
+      meta-tedge:

--- a/kas/projects/tedge-rugix.lock.yaml
+++ b/kas/projects/tedge-rugix.lock.yaml
@@ -2,17 +2,17 @@ header:
   version: 14
 overrides:
   repos:
-    meta-lts-mixins-go:
-      commit: 4e092daf1e920a44fb51d6df67cbddc9bc399e33
-    meta-lts-mixins-rust:
-      commit: 895b8b76de6dea32ba53b86e4db3ec5b9b275f28
-    meta-openembedded:
-      commit: 06fc0278f10d630838d703dde707bbf0e2999873
-    meta-raspberrypi:
-      commit: 39e5dfd9cb8f11eda189d0beb62d27c83fc57e75
-    meta-rugix:
-      commit: 22e60ef3aeb07f630af163a5ad1aef42ac8e97e6
-    meta-virtualization:
-      commit: 3e4dba95e6b5f5f68d0b3a5899b106c89da59428
     poky:
       commit: f4219fb3e291eaffbb475b91ad4a8c4772a9c7d3
+    meta-raspberrypi:
+      commit: 39e5dfd9cb8f11eda189d0beb62d27c83fc57e75
+    meta-openembedded:
+      commit: 06fc0278f10d630838d703dde707bbf0e2999873
+    meta-rugix:
+      commit: 22e60ef3aeb07f630af163a5ad1aef42ac8e97e6
+    meta-lts-mixins-rust:
+      commit: 895b8b76de6dea32ba53b86e4db3ec5b9b275f28
+    meta-lts-mixins-go:
+      commit: 4e092daf1e920a44fb51d6df67cbddc9bc399e33
+    meta-virtualization:
+      commit: 3e4dba95e6b5f5f68d0b3a5899b106c89da59428

--- a/meta-tedge-common/recipes-core/images/core-image-tedge.bb
+++ b/meta-tedge-common/recipes-core/images/core-image-tedge.bb
@@ -2,6 +2,7 @@ require recipes-core/images/core-image-base.bb
 
 IMAGE_INSTALL:append = " \
     tedge \
+    tedge-p11-server \
     tedge-command-plugin \
     opensc \
     gnutls-bin \

--- a/meta-tedge/classes/tedge-user.bbclass
+++ b/meta-tedge/classes/tedge-user.bbclass
@@ -1,0 +1,12 @@
+# Create tedge user and group
+inherit useradd
+USERADD_PACKAGES = "${PN}"
+GROUPADD_PARAM:${PN} = "--system --gid 950 tedge"
+USERADD_PARAM:${PN} = "--system --no-create-home --shell /sbin/nologin --uid 951 --gid 950 tedge"
+
+TEDGE_CONFIG_DIR ?= "/etc/tedge"
+
+do_install:append () {
+    install -d ${D}${TEDGE_CONFIG_DIR}
+    chown -R tedge:tedge "${D}${TEDGE_CONFIG_DIR}"
+}

--- a/meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server.inc
+++ b/meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server.inc
@@ -1,0 +1,38 @@
+SUMMARY = "A thin-edge server that allows thin-edge service possibly working in a container to access host's cryptographic tokens."
+HOMEPAGE = "https://thin-edge.io"
+LICENSE = "Apache-2.0"
+
+inherit cargo-tedge tedge-user
+inherit ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}
+
+SRC_URI += "\
+    git://git@github.com/thin-edge/thin-edge.io.git;protocol=https;branch=main;name=tedge \
+    git://git@github.com/thin-edge/tedge-services.git;protocol=https;branch=main;name=tedge-services;destsuffix=tedge-services \
+    "
+
+LIC_FILES_CHKSUM = " \
+    file://LICENSE.txt;md5=175792518e4ac015ab6696d16c4f607e \
+"
+
+TEDGE_CONFIG_DIR ?= "/etc/tedge"
+
+CARGO_BUILD_FLAGS:append = " --bin tedge-p11-server"
+
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${systemd_system_unitdir}
+        install -m 0644 ${WORKDIR}/tedge-services/services/systemd/system/tedge-p11-server.service ${D}${systemd_system_unitdir}
+        install -m 0644 ${WORKDIR}/tedge-services/services/systemd/system/tedge-p11-server.socket ${D}${systemd_system_unitdir}
+    fi
+
+    install -d ${D}${TEDGE_CONFIG_DIR}
+    chown -R tedge:tedge "${D}${TEDGE_CONFIG_DIR}"
+}
+
+FILES:${PN} += "\
+    ${bindir}/tedge-p11-server \
+    ${systemd_system_unitdir}/tedge-p11-server.service \
+    ${systemd_system_unitdir}/tedge-p11-server.socket \
+"
+
+SYSTEMD_SERVICE:${PN} += "tedge-p11-server.socket"

--- a/meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server/tedge.toml.example
+++ b/meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server/tedge.toml.example
@@ -1,0 +1,9 @@
+[config]
+version = "2"
+
+[device.cryptoki]
+mode = "socket"
+module_path = "/usr/lib/softhsm/libsofthsm2.so"
+pin = "123456"
+uri = "pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=83f9cf49039c051a;token=my-token;id=%01;object=my-key;type=private"
+socket_path = "/run/tedge-p11-server/tedge-p11-server.sock"

--- a/meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server_1.5.1.bb
+++ b/meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server_1.5.1.bb
@@ -1,0 +1,6 @@
+SRCREV_tedge = "1ec3eed5cc6b6cd9282195cb205bde3635ecfece"
+SRCREV_tedge-services = "f495b82f0002be81a7778483003139a223a508a1"
+SRCREV_FORMAT = "tedge"
+S = "${WORKDIR}/git"
+
+require tedge-p11-server.inc

--- a/meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server_1.6.0.bb
+++ b/meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server_1.6.0.bb
@@ -1,0 +1,6 @@
+SRCREV_tedge = "a93d3fbcaf04c0a62cf4a1453309d72017c105f5"
+SRCREV_tedge-services = "f495b82f0002be81a7778483003139a223a508a1"
+SRCREV_FORMAT = "tedge"
+S = "${WORKDIR}/git"
+
+require tedge-p11-server.inc

--- a/meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server_git.bb
+++ b/meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server_git.bb
@@ -1,0 +1,8 @@
+SRCREV_tedge = "${AUTOREV}"
+SRCREV_tedge-services = "${AUTOREV}"
+SRCREV_FORMAT = "tedge"
+S = "${WORKDIR}/git"
+PV = "1.7+git${SRCPV}"
+DEFAULT_PREFERENCE = "-1"
+
+require tedge-p11-server.inc

--- a/meta-tedge/recipes-tedge/tedge/tedge-services.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-services.inc
@@ -3,13 +3,16 @@ SRC_URI += "git://git@github.com/thin-edge/tedge-services.git;protocol=https;bra
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'update-rc.d', '', d)}
 
+# tedge-p11-server is defined in a seprated recipe
+TEDGE_EXCLUDE += "tedge-p11-server"
+
 do_install:append () {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
 		install -d ${D}${systemd_system_unitdir}
         
         for service in ${WORKDIR}/tedge-services/services/systemd/system/*; do
-            filename=$(basename "$service" ".service" | cut -d. -f1)
-            if ! echo "${@d.getVar('TEDGE_EXCLUDE')}" | grep -iq $filename; then
+            unit_name=$(basename "$service" | cut -d. -f1)
+            if ! echo "${@d.getVar('TEDGE_EXCLUDE')}" | grep -qw "$unit_name"; then
                 install -m 0644 $service ${D}${systemd_system_unitdir}
             fi
         done 
@@ -35,7 +38,7 @@ do_install:append () {
     fi
 }
 
-PACKAGES += "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-p11-server"
+PACKAGES += "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd"
 
 FILES:${PN} += "\
     ${sysconfdir}/init.d/* \
@@ -64,15 +67,10 @@ FILES:${PN}-mapper-az += "\
 FILES:${PN}-mapper-collectd += "\
     ${systemd_system_unitdir}/tedge-mapper-collectd.service \
 "
-FILES:${PN}-p11-server += "\
-    ${systemd_system_unitdir}/tedge-p11-server.service \
-    ${systemd_system_unitdir}/tedge-p11-server.socket \
-"
 
-SYSTEMD_PACKAGES = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-p11-server"
+SYSTEMD_PACKAGES += "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd"
 SYSTEMD_SERVICE:${PN}-agent = "tedge-agent.service"
 SYSTEMD_SERVICE:${PN}-mapper-c8y = "tedge-mapper-c8y.service c8y-remote-access-plugin@.service c8y-remote-access-plugin.socket"
 SYSTEMD_SERVICE:${PN}-mapper-aws = "tedge-mapper-aws.service"
 SYSTEMD_SERVICE:${PN}-mapper-az = "tedge-mapper-az.service"
 SYSTEMD_SERVICE:${PN}-mapper-collectd = "tedge-mapper-collectd.service"
-SYSTEMD_SERVICE:${PN}-p11-server = "tedge-p11-server.socket"

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -14,14 +14,9 @@ SUMMARY = "tedge is the cli tool for thin-edge.io"
 HOMEPAGE = "https://thin-edge.io"
 LICENSE = "Apache-2.0"
 
-inherit cargo-tedge useradd
+inherit cargo-tedge tedge-user
 
-RDEPENDS:${PN} = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd ${PN}-p11-server mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo"
-
-USERADD_PACKAGES = "${PN}"
-GROUPADD_PARAM:${PN} = "--system --gid 950 tedge"
-USERADD_PARAM:${PN} = "--system --no-create-home --shell /sbin/nologin --uid 951 --gid 950 tedge"
-
+RDEPENDS:${PN} = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo"
 TEDGE_CONFIG_DIR ?= "/etc/tedge"
 TEDGE_CONFIG_SYMLINK ?= ""
 TEDGE_CONFIG_SYMLINK_SRC ?= ""


### PR DESCRIPTION
Porting the change from scarthgap (#280) to kirkstone.

Linked issue: https://github.com/thin-edge/meta-tedge/issues/248