### PR TITLE
fix(kirkstone): remove base-files

### DIFF
--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -16,7 +16,7 @@ local_conf_header:
     TEDGE_CONFIG_DIR = "/etc/tedge"
 
     # customize tedge features
-    TEDGE_FEATURES_ENABLE:append = " tedge-logs tedge-collectd tedge-docker tedge-p11-kit"
+    TEDGE_FEATURES_ENABLE:append = " tedge-collectd tedge-docker tedge-p11-kit"
 
     # enable CVE checks
     CVE_CHECK_MANIFEST_JSON_SUFFIX ?= "cve.json"

--- a/kas/config/minimal.yaml
+++ b/kas/config/minimal.yaml
@@ -13,7 +13,7 @@ local_conf_header:
     EXTRA_IMAGE_FEATURES ?= "debug-tweaks ssh-server-dropbear"
 
     # Enable the tedge feature and its underlying system configurations
-    TEDGE_FEATURES_ENABLE:append = " tedge-logs tedge-collectd tedge-p11-kit"
+    TEDGE_FEATURES_ENABLE:append = " tedge-collectd tedge-p11-kit"
     TEDGE_FEATURES_DISABLE:append = " tedge-docker"
 
     # systemd is recommended

--- a/meta-tedge-common/classes/tedge-features.bbclass
+++ b/meta-tedge-common/classes/tedge-features.bbclass
@@ -25,7 +25,6 @@ DISTROOVERRIDES:append = ":${@tedge_features(d, separator=':')}"
 python() {
     available_features = {
         'tedge-collectd',
-        'tedge-logs',
         'tedge-docker',
         'tedge-p11-kit'
     }

--- a/meta-tedge-common/conf/layer.conf
+++ b/meta-tedge-common/conf/layer.conf
@@ -14,4 +14,4 @@ LAYERDEPENDS_meta-tedge-common = "core networking-layer"
 LAYERSERIES_COMPAT_meta-tedge-common = "kirkstone"
 
 INHERIT += "tedge-features"
-TEDGE_FEATURES_ENABLE ??= "tedge-logs tedge-collectd tedge-docker tedge-p11-kit"
+TEDGE_FEATURES_ENABLE ??= "tedge-collectd tedge-docker tedge-p11-kit"

--- a/meta-tedge-common/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-tedge-common/recipes-core/base-files/base-files_%.bbappend
@@ -1,5 +1,0 @@
-dirs755:remove:tedge-logs = "${localstatedir}/volatile/log"
-volatiles:remove:tedge-logs = "log"
-
-volatiles:append:tedge-logs = "tmp"
-dirs755:append:tedge-logs = "${localstatedir}/log"


### PR DESCRIPTION
Remove the base-files receipe from the layer as it not required, had some bugs (missing leading space when appending a value), and is control settings which are better to be left up to the user.

The var/log setting was anyway made redundant due to the usage of `VOLATILE_LOG_DIR = "no"` in the config/common.yaml (as part of the kas configuration files).

Related issues:
* https://github.com/thin-edge/meta-tedge/issues/314