### PR TITLE
fix(kirkstone): fix vnstat inflated traffic counters after a firmware update

### DIFF
--- a/meta-tedge-common/recipes-support/vnstat/vnstat/0001-Sync-counters-on-startup-to-avoid-jump-in-counters-w.patch
+++ b/meta-tedge-common/recipes-support/vnstat/vnstat/0001-Sync-counters-on-startup-to-avoid-jump-in-counters-w.patch
@@ -1,0 +1,23 @@
+From 99ee9a731bd1940e7ffaa10f2727a2da6476b463 Mon Sep 17 00:00:00 2001
+From: Reuben Miller <reuben.d.miller@gmail.com>
+Date: Tue, 16 Sep 2025 22:12:30 +0200
+Subject: [PATCH] Sync counters on startup to avoid jump in counters when
+ switching partitions
+
+---
+ examples/systemd/vnstat.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/examples/systemd/vnstat.service b/examples/systemd/vnstat.service
+index 4f2d27f..53821b9 100644
+--- a/examples/systemd/vnstat.service
++++ b/examples/systemd/vnstat.service
+@@ -6,7 +6,7 @@ StartLimitIntervalSec=20
+ StartLimitBurst=4
+ 
+ [Service]
+-ExecStart=/usr/sbin/vnstatd -n
++ExecStart=/usr/sbin/vnstatd -n --sync
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
+ RestartSec=2

--- a/meta-tedge-common/recipes-support/vnstat/vnstat_%.bbappend
+++ b/meta-tedge-common/recipes-support/vnstat/vnstat_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Sync-counters-on-startup-to-avoid-jump-in-counters-w.patch"


### PR DESCRIPTION
Syncing the counters avoids an issue when switching partitions during a firmware update where the counters could be inflated by ~4GB. See https://github.com/vergoh/vnstat/issues/40 for some hints about the fix.

The inflated vnstat statistics ticket was originally tracked in https://github.com/thin-edge/thin-edge.io/issues/3754. Though after a thorough investigation, no fault was found in thin-edge.io or rugix.

