### PR TITLE
ci(kirkstone): reduce disk usage during builds

### DIFF
--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -8,6 +8,9 @@ bblayers_conf_header:
 
 local_conf_header:
   meta-common: |
+    # conserve disk space during a build
+    INHERIT += "rm_work"
+
     PACKAGE_CLASSES ?= "package_deb"
     VOLATILE_LOG_DIR = "no"
     IMAGE_INSTALL:append = " gnupg"


### PR DESCRIPTION
Reduce the amount of disk space used whilst building (under `TMPDIR`).

Reference
* https://docs.yoctoproject.org/dev-manual/disk-space.html#conserving-disk-space-during-builds