### PR TITLE
feat(scarthgap): exclude additional packages from the cloud's software list

### DIFF
--- a/meta-tedge-bin/recipes-tedge/tedge-bin/files/tedge.toml
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/files/tedge.toml
@@ -8,4 +8,4 @@ path = "/data/tedge/data"
 path = "/data/tedge/log"
 
 [software.plugin]
-exclude = "^(glibc|lib|kernel-|iptables-module).*"
+exclude = "^(glibc|lib|kernel-|iptables-module|util-linux|packagegroup-|pam-plugin-|alsa-|linux-firmware-|bluez-firmware-|e2fsprogs).*"

--- a/meta-tedge/recipes-tedge/tedge/tedge/tedge.toml
+++ b/meta-tedge/recipes-tedge/tedge/tedge/tedge.toml
@@ -8,4 +8,4 @@ path = "/data/tedge/data"
 path = "/data/tedge/log"
 
 [software.plugin]
-exclude = "^(glibc|lib|kernel-|iptables-module).*"
+exclude = "^(glibc|lib|kernel-|iptables-module|util-linux|packagegroup-|pam-plugin-|alsa-|linux-firmware-|bluez-firmware-|e2fsprogs).*"


### PR DESCRIPTION
Exclude additional software packages which aren't relevant to the maintaince of the device and can be referenced from the device's SBOM.

https://github.com/thin-edge/meta-tedge/issues/287