### PR TITLE
ci: Retry the build after the first failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,7 +90,7 @@ jobs:
         if: ${{ !startsWith(runner.name, 'tedge') }}
 
       - name: Build
-        run: just build-project projects/${{ matrix.project }}.yaml
+        run: just build-project projects/${{ matrix.project }}.yaml || { echo "retrying the build" && just build-project projects/${{ matrix.project }}.yaml }
         working-directory: kas
         env:
           KAS_MACHINE: ${{ matrix.machine }}


### PR DESCRIPTION
The patch for this kind of random build failure: https://github.com/thin-edge/meta-tedge/actions/runs/18409661842/job/52458302667?pr=333