### PR TITLE
ci: fix the syntax error

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,7 +90,7 @@ jobs:
         if: ${{ !startsWith(runner.name, 'tedge') }}
 
       - name: Build
-        run: just build-project projects/${{ matrix.project }}.yaml || { echo "retrying the build" && just build-project projects/${{ matrix.project }}.yaml }
+        run: just build-project projects/${{ matrix.project }}.yaml || { echo "retrying the build" && just build-project projects/${{ matrix.project }}.yaml; }
         working-directory: kas
         env:
           KAS_MACHINE: ${{ matrix.machine }}


### PR DESCRIPTION
Fix the syntax error introduced by #334.

I tested the syntax on `zsh`, but it was wrong, should've tested on `bash`...

✅  Works on `zsh`
```sh
tedge-yocto-01% false || {echo "bbb" && echo "ccc"}
bbb
ccc
```

❌ Not on `bash` 
```sh
tedge-yocto-01:~/meta-tedge$ false || {echo "bbb" && echo "ccc"}
bash: {echo: command not found
```

✅ Works on both
```sh
tedge-yocto-01:~/meta-tedge$ false || { echo "bbb" && echo "ccc"; }
bbb
ccc
```