### PR TITLE
ci(scarthgap): Warn the retry message on GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,7 +90,7 @@ jobs:
         if: ${{ !startsWith(runner.name, 'tedge') }}
 
       - name: Build
-        run: just build-project projects/${{ matrix.project }}.yaml || { echo "retrying the build" && just build-project projects/${{ matrix.project }}.yaml; }
+        run: just build-project projects/${{ matrix.project }}.yaml || { echo "::warning title=Retried build for ${{ matrix.project }} ${{ matrix.machine }}::The initial build failed and retried." && just build-project projects/${{ matrix.project }}.yaml; }
         working-directory: kas
         env:
           KAS_MACHINE: ${{ matrix.machine }}


### PR DESCRIPTION
Port the change from kirkstone to scarthgap by #336 