### PR TITLE
fix(scarthgap): skip building tedge-flows due to build issue

### DIFF
--- a/meta-tedge/recipes-tedge/tedge/tedge_git.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_git.bb
@@ -9,3 +9,6 @@ TEDGE_EXCLUDE = "c8y-firmware-plugin"
 
 require tedge.inc
 require tedge-diag.inc
+
+# build tedge without tedge-flows due to an issue with rquickjs and bindgen
+CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -146,6 +146,9 @@ TEDGE_EXCLUDE = "c8y-firmware-plugin"
 
 require tedge.inc
 require tedge-diag.inc
+
+# build tedge without tedge-flows due to an issue with rquickjs and bindgen
+CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "
 EOT
 
     # Generate tedge-p11-server BB file
@@ -184,6 +187,9 @@ DEFAULT_PREFERENCE = "-1"
 TEDGE_EXCLUDE = "c8y-firmware-plugin"
 
 require tedge.inc
+
+# build tedge without tedge-flows due to an issue with rquickjs and bindgen
+CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "
 EOT
 
     tedge_p11_server_git_bb_file="meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server_git.bb"


### PR DESCRIPTION
Skip building tedge-flows when building thin-edge.io from the latest main branch due to some build issues due to the usage of rquickjs within the tedge-flows.

The issue seems to be with the auto generation of the quickjs bindings which requires bindgen. Until this issue is resolved, the tedge-flows will be ignored within the Yocto layer.
