### PR TITLE
chore(scarthgap): add tedge-diag.inc to tedge_git.bb file

### DIFF
--- a/meta-tedge/recipes-tedge/tedge/tedge_git.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_git.bb
@@ -8,3 +8,4 @@ DEFAULT_PREFERENCE = "-1"
 TEDGE_EXCLUDE = "c8y-firmware-plugin"
 
 require tedge.inc
+require tedge-diag.inc


### PR DESCRIPTION
Follow-up of #349, which forgot to include the `tedge-diag.inc` in the `tedge_git.bb` file.