### PR TITLE
wip: support building tedge-flows

### DIFF
--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -28,7 +28,8 @@ local_conf_header:
 
     # preferred thin-edge.io version
     # Use "1.X%" if you want to use the latest from the main branch
-    #PREFERRED_VERSION_tedge ?= "1.6.1"
+    PREFERRED_VERSION_tedge ?= "1.7%"
+    PREFERRED_VERSION_tedge-p11-server ?= "1.7%"
 
     # Add /etc/buildinfo file with information about build
     INHERIT += "image-buildinfo"

--- a/kas/projects/tedge-rugix-tpm2.yaml
+++ b/kas/projects/tedge-rugix-tpm2.yaml
@@ -74,6 +74,9 @@ repos:
     url: "https://git.yoctoproject.org/meta-lts-mixins"
     branch: scarthgap/rust
 
+  meta-clang:
+    url: "https://github.com/kraj/meta-clang.git"
+
   meta-lts-mixins-go:
     url: "https://github.com/thin-edge/meta-lts-mixins.git"
     branch: scarthgap/go

--- a/meta-tedge/recipes-tedge/tedge/tedge_git.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_git.bb
@@ -11,4 +11,20 @@ require tedge.inc
 require tedge-diag.inc
 
 # build tedge without tedge-flows due to an issue with rquickjs and bindgen
-CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "
+CARGO_BUILD_FLAGS:append = " --bin tedge "
+DEPENDS += "clang-native"
+
+# Remove unsupported GCC flag causing cc-rs crates to fail
+CFLAGS:remove = "-fcanon-prefix-map"
+BUILD_CFLAGS:remove = "-fcanon-prefix-map"
+TARGET_CFLAGS:remove = "-fcanon-prefix-map"
+CARGO_BUILD_TARGET_CFLAGS:remove = "-fcanon-prefix-map"
+
+export BINDGEN_EXTRA_CLANG_ARGS
+target = "${@d.getVar('TARGET_SYS').replace('-', ' ')}"
+BINDGEN_EXTRA_CLANG_ARGS = "${@bb.utils.contains('target', 'arm', \
+                              '--target=${RUST_TARGET_SYS} --sysroot=${WORKDIR}/recipe-sysroot -I${WORKDIR}/recipe-sysroot/usr/include -mfloat-abi=hard', \
+                              '--target=${RUST_TARGET_SYS} --sysroot=${WORKDIR}/recipe-sysroot -I${WORKDIR}/recipe-sysroot/usr/include', \
+                              d)}"
+
+# RUST_HOST_SYS and RUST_TARGET_SYS

--- a/meta-tedge/recipes-tedge/tedge/tedge_git.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_git.bb
@@ -9,3 +9,6 @@ TEDGE_EXCLUDE = "c8y-firmware-plugin"
 
 require tedge.inc
 require tedge-diag.inc
+
+# build tedge without tedge-flows due to an issue with rquickjs and bindgen
+CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -146,6 +146,9 @@ TEDGE_EXCLUDE = "c8y-firmware-plugin"
 
 require tedge.inc
 require tedge-diag.inc
+
+# build tedge without tedge-flows due to an issue with rquickjs and bindgen
+CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "
 EOT
 
     # Generate tedge-p11-server BB file
@@ -184,6 +187,9 @@ DEFAULT_PREFERENCE = "-1"
 TEDGE_EXCLUDE = "c8y-firmware-plugin"
 
 require tedge.inc
+
+# build tedge without tedge-flows due to an issue with rquickjs and bindgen
+CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "
 EOT
 
     tedge_p11_server_git_bb_file="meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server_git.bb"


### PR DESCRIPTION
TODO:
* Activate bindgen feature for rquickjs within the thin-edge.io project
* Debug build issue when bindgen is active but invalid symbols are produced
* Minimize number of changes as much as possible (as some changes probably don't have any effect)

**Check building on main branch**

```sh
just build-project ./projects/tedge-rugix-tpm2.yaml
```

**Process to edit the tedge recipe and source code**
1. Open a shell with the project

    ```sh
    cd kas
    just shell ./projects/tedge-rugix-tpm2.yaml
    ```

1. Start the devtool to modify the tedge recipe

    ```sh
    devtool modify tedge
    ```

1. Edit the tedge recipe under the path which is displayed on the console

    ```sh
    /home/<user>/meta-tedge/kas/build/workspace/sources/tedge
    ```

    For example, edit the tedge flows Cargo.toml to enable the bindgen feature
    * kas/build/workspace/sources/tedge/crates/extensions/tedge_flows/Cargo.toml

1. Try building the recipe (at first)

    ```sh
    devtool build tedge
    ```

### Current errors


```sh
$ dev build tedge

| error: could not compile `rquickjs-macro` (lib) due to 1 previous error
| 
| Caused by:
|   process didn't exit successfully: `rustc --crate-name rquickjs_macro --edition=2021 /home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/cargo_home/git/checkouts/rquickjs-c63fb1eb340910d5/4ed04ac/macro/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type proc-macro --emit=dep-info,link -C prefer-dynamic -C embed-bitcode=no -C debug-assertions=off -C overflow-checks=on --cfg 'feature="bindgen"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("bindgen", "phf", "phf_generator", "phf_shared"))' -C metadata=690984d5acee5895 -C extra-filename=-16c1c5dd893fa33e --out-dir /home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps -C linker=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/wrapper/build-rust-ccld -L dependency=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps --extern convert_case=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps/libconvert_case-3c195678cd01a07f.rlib --extern fnv=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps/libfnv-3db35ffac32ba2b3.rlib --extern ident_case=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps/libident_case-a6f2c3714fe2613b.rlib --extern indexmap=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps/libindexmap-e29f202e6610877f.rlib --extern proc_macro_crate=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps/libproc_macro_crate-308f91a0bfd19cb1.rlib --extern proc_macro2=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps/libproc_macro2-962e990bb94dce8c.rlib --extern quote=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps/libquote-b867f1cd29fa0a18.rlib --extern rquickjs_core=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps/librquickjs_core-72728391252d7576.rlib --extern syn=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/deps/libsyn-6d35dfeae37e5615.rlib --extern proc_macro --cap-lints allow -L native=/home/reubenmiller/meta-tedge/kas/build/tmp/work/cortexa53-poky-linux/tedge/1.7+git/tedge-1.7+git/target/release/build/rquickjs-sys-0a40c52c997295d2/out` (exit status: 1)
| warning: build failed, waiting for other jobs to finish...
|     Building [======================>  ] 577/605: tedge_config
| WARNING: exit code 101 from a shell command.
ERROR: Task (/home/reubenmiller/meta-tedge/kas/build/../../meta-tedge/recipes-tedge/tedge/tedge_git.bb:do_compile) failed with exit code '1'
```
