### PR TITLE
chore(scarthgap): include tedge-diag.inc in the recipe generation script

### DIFF
--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -187,6 +187,7 @@ DEFAULT_PREFERENCE = "-1"
 TEDGE_EXCLUDE = "c8y-firmware-plugin"
 
 require tedge.inc
+require tedge-diag.inc
 
 # build tedge without tedge-flows due to an issue with rquickjs and bindgen
 CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "


### PR DESCRIPTION
In the previous PR (#373), the change on `admin.sh` was missing. Good catch during the review in #375 by @reubenmiller. Port back the fix to scarthgap from kirkstone.

Need to resolve the conflict. Once it's dine, I'll open up the PR