### PR TITLE
build: enable tedge-flows build

### DIFF
--- a/kas/config/common.yaml
+++ b/kas/config/common.yaml
@@ -28,7 +28,8 @@ local_conf_header:
 
     # preferred thin-edge.io version
     # Use "1.X%" if you want to use the latest from the main branch
-    #PREFERRED_VERSION_tedge ?= "1.6.1"
+    PREFERRED_VERSION_tedge ?= "1.7%"
+    PREFERRED_VERSION_tedge-p11-server ?= "1.7%"
 
     # Add /etc/buildinfo file with information about build
     INHERIT += "image-buildinfo"

--- a/meta-tedge/recipes-tedge/tedge/tedge/0001-Cargo.toml-change-rev-of-rquickjs.patch
+++ b/meta-tedge/recipes-tedge/tedge/tedge/0001-Cargo.toml-change-rev-of-rquickjs.patch
@@ -1,0 +1,13 @@
+diff --git a/crates/extensions/tedge_flows/Cargo.toml b/crates/extensions/tedge_flows/Cargo.toml
+index 51d7ba14b..f28173104 100644
+--- a/crates/extensions/tedge_flows/Cargo.toml
++++ b/crates/extensions/tedge_flows/Cargo.toml
+@@ -14,7 +14,7 @@ async-trait = { workspace = true }
+ camino = { workspace = true, features = ["serde1"] }
+ futures = { workspace = true }
+ humantime = { workspace = true }
+-rquickjs = { git = "https://github.com/thin-edge/rquickjs", rev = "4ed04ac9af3de453dd41ff09fdd1837c7ceb1f1c", default-features = false, features = [
++rquickjs = { git = "https://github.com/rina23q/rquickjs", rev = "d5db616760878c9d27f1d9b7fc37b8d572d97948", default-features = false, features = [
+     # disable bindgen and rely on pre-generated bindings due to problems
+     # generating the bindings at build time with clang
+     #"bindgen",

--- a/meta-tedge/recipes-tedge/tedge/tedge_git.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_git.bb
@@ -10,5 +10,9 @@ TEDGE_EXCLUDE = "c8y-firmware-plugin"
 require tedge.inc
 require tedge-diag.inc
 
-# build tedge without tedge-flows due to an issue with rquickjs and bindgen
-CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "
+CARGO_BUILD_FLAGS:append = " --bin tedge"
+DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
+
+SRC_URI += "\
+file://0001-Cargo.toml-change-rev-of-rquickjs.patch \
+"


### PR DESCRIPTION
Two things required to enable tedge-flows build.

### 1. Prepare bindings for all poky targets
In Yocto, all targets given to `cargo build` have "poky" name as distribution as below.
```
"cargo" build -v  --target armv7-poky-linux-gnueabihf --release --manifest-path=/home/rina23q/meta-tedge/kas/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/tedge/1.7+git/git//Cargo.toml --config 'profile.release.strip="none"' --bin tedge  "$@"
```
So, I prepared bindings for `rquickjs` for the following targets.
- arm-poky-linux-gnueabihf
- armv7-poky-linux-gnueabihf
- aarch64-poky-linux-gnu
- x86_64-poky-linux-gnu

### 2. Solve `-fcanon-prefix-map` problem
This seems an known issue with the combination of scarthgap + Rust 1.87. `meta-lts-mixins-rust` left the following comment. (`meta-lts-mixins-rust/recipes-devtools/rust/rust_%.bbappend`)
```
# Override scarthgap default of "-fcanon-prefix-map" as it seems to
# now cause issues with rust-llvm as of Rust 1.87.  master branch
# did not see this as the default value changed to the below before
# the upgrade to Rust 1.86.
DEBUG_PREFIX_MAP = "\
 -ffile-prefix-map=${S}=${TARGET_DBGSRC_DIR} \
 -ffile-prefix-map=${B}=${TARGET_DBGSRC_DIR} \
 -ffile-prefix-map=${STAGING_DIR_HOST}= \
 -ffile-prefix-map=${STAGING_DIR_NATIVE}= \
"
```
Also, `meta-openembedded/meta-networking` removes as below. (`kas/meta-openembedded/meta-networking/recipes-protocols/frr/frr_9.1.3.bb`)
```
DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
```
So, I took the same approach as `meta-networking` does.

---

Currently, I put my forked `rquickjs` and commit in the Cargo.toml patch file. I am planning to port the change to `thin-edge/rquickjs` and update the patch file, or can update the Cargo.toml in our thin-edge.io repository directly. If we do the latter, we don't need the patch file.

Also, when running `tedge-mapper flows`, this error was printed. After creating the directory manually, no more error was recorded. I think we have to add the directory to our tedge recipe.
```
2025-11-28T20:57:44.017388629Z ERROR flows: Failed to read flows from /etc/tedge/flows: No such file or directory (os error 2)
2025-11-28T20:57:44.018777886Z ERROR tedge_file_system_ext: Failed to add file watcher to the /etc/tedge/flows due to: No such file or directory (os error 2)
```