### PR TITLE
build(scarthgap): enable bindgen

### DIFF
--- a/kas/projects/tedge-bin-rauc.lock.yaml
+++ b/kas/projects/tedge-bin-rauc.lock.yaml
@@ -3,16 +3,16 @@ header:
 overrides:
   repos:
     poky:
-      commit: 553530a8acce3b078473c0fa512246a3e84d46bf
+      commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
     meta-raspberrypi:
       commit: 2c646d29912dcc873469a57b1c207e1549c5094d
     meta-openembedded:
-      commit: b4812b18eec77e9f0286bd6b81a5c3032ac0d3be
+      commit: 2b26d30fc7f478f5735d514f0c1bc28f6a4148b6
     meta-rauc:
       commit: a0f4a8b9986954239850b9d4256c003c91e6b931
     meta-rauc-community:
       commit: 935ea34c32fcdc70b5f48a7f6a6a32b1af65081d
     meta-virtualization:
-      commit: 17ac21e7d7f6f40a87618b22278b63bcfa14dbf2
+      commit: f92518e20530edfebca45e4170e11460949a5303
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13

--- a/kas/projects/tedge-core.lock.yaml
+++ b/kas/projects/tedge-core.lock.yaml
@@ -3,8 +3,10 @@ header:
 overrides:
   repos:
     poky:
-      commit: 553530a8acce3b078473c0fa512246a3e84d46bf
+      commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
     meta-openembedded:
-      commit: b4812b18eec77e9f0286bd6b81a5c3032ac0d3be
+      commit: 2b26d30fc7f478f5735d514f0c1bc28f6a4148b6
     meta-lts-mixins-rust:
       commit: 00c30d00f7377ee426b017bb46dd8c4c7eeea03b
+    meta-clang:
+      commit: 5c602337ea1a80fb7217eeda04e396cf90587dca

--- a/kas/projects/tedge-core.yaml
+++ b/kas/projects/tedge-core.yaml
@@ -37,3 +37,6 @@ repos:
     layers:
       meta-tedge:
       meta-tedge-common:
+
+  meta-clang:
+    url: "https://github.com/kraj/meta-clang.git"

--- a/kas/projects/tedge-mender-qemu.lock.yaml
+++ b/kas/projects/tedge-mender-qemu.lock.yaml
@@ -3,14 +3,16 @@ header:
 overrides:
   repos:
     poky:
-      commit: 553530a8acce3b078473c0fa512246a3e84d46bf
+      commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
     meta-openembedded:
-      commit: b4812b18eec77e9f0286bd6b81a5c3032ac0d3be
+      commit: 2b26d30fc7f478f5735d514f0c1bc28f6a4148b6
     meta-mender:
-      commit: 69e0cfc3eee0b070510720d70f8a62440c995317
+      commit: 9d6ba42c6b77e128cfbeec412f7d2bf9772eb03f
     meta-lts-mixins-rust:
       commit: 00c30d00f7377ee426b017bb46dd8c4c7eeea03b
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
     meta-virtualization:
-      commit: 17ac21e7d7f6f40a87618b22278b63bcfa14dbf2
+      commit: f92518e20530edfebca45e4170e11460949a5303
+    meta-clang:
+      commit: 5c602337ea1a80fb7217eeda04e396cf90587dca

--- a/kas/projects/tedge-mender-qemu.yaml
+++ b/kas/projects/tedge-mender-qemu.yaml
@@ -63,3 +63,6 @@ repos:
 
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
+
+  meta-clang:
+    url: "https://github.com/kraj/meta-clang.git"

--- a/kas/projects/tedge-mender-tpm2.lock.yaml
+++ b/kas/projects/tedge-mender-tpm2.lock.yaml
@@ -3,15 +3,15 @@ header:
 overrides:
   repos:
     poky:
-      commit: 553530a8acce3b078473c0fa512246a3e84d46bf
+      commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
     meta-raspberrypi:
       commit: 2c646d29912dcc873469a57b1c207e1549c5094d
     meta-openembedded:
-      commit: b4812b18eec77e9f0286bd6b81a5c3032ac0d3be
+      commit: 2b26d30fc7f478f5735d514f0c1bc28f6a4148b6
     meta-security:
       commit: afbbe28cee4af2c6760aaead43a4a3ef29969809
     meta-mender:
-      commit: 69e0cfc3eee0b070510720d70f8a62440c995317
+      commit: 9d6ba42c6b77e128cfbeec412f7d2bf9772eb03f
     meta-mender-community:
       commit: 9145b8e34bac23c82984ddcdd5468154ffe7af6d
     meta-lts-mixins-rust:
@@ -21,4 +21,6 @@ overrides:
     meta-lts-mixins-u-boot:
       commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
-      commit: 17ac21e7d7f6f40a87618b22278b63bcfa14dbf2
+      commit: f92518e20530edfebca45e4170e11460949a5303
+    meta-clang:
+      commit: 5c602337ea1a80fb7217eeda04e396cf90587dca

--- a/kas/projects/tedge-mender-tpm2.yaml
+++ b/kas/projects/tedge-mender-tpm2.yaml
@@ -85,3 +85,6 @@ repos:
 
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
+
+  meta-clang:
+    url: "https://github.com/kraj/meta-clang.git"

--- a/kas/projects/tedge-mender.lock.yaml
+++ b/kas/projects/tedge-mender.lock.yaml
@@ -3,13 +3,13 @@ header:
 overrides:
   repos:
     poky:
-      commit: 553530a8acce3b078473c0fa512246a3e84d46bf
+      commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
     meta-raspberrypi:
       commit: 2c646d29912dcc873469a57b1c207e1549c5094d
     meta-openembedded:
-      commit: b4812b18eec77e9f0286bd6b81a5c3032ac0d3be
+      commit: 2b26d30fc7f478f5735d514f0c1bc28f6a4148b6
     meta-mender:
-      commit: 69e0cfc3eee0b070510720d70f8a62440c995317
+      commit: 9d6ba42c6b77e128cfbeec412f7d2bf9772eb03f
     meta-mender-community:
       commit: 9145b8e34bac23c82984ddcdd5468154ffe7af6d
     meta-lts-mixins-rust:
@@ -19,4 +19,6 @@ overrides:
     meta-lts-mixins-u-boot:
       commit: a44882db02a0ed0f149371831bfbe067665eb42b
     meta-virtualization:
-      commit: 17ac21e7d7f6f40a87618b22278b63bcfa14dbf2
+      commit: f92518e20530edfebca45e4170e11460949a5303
+    meta-clang:
+      commit: 5c602337ea1a80fb7217eeda04e396cf90587dca

--- a/kas/projects/tedge-mender.yaml
+++ b/kas/projects/tedge-mender.yaml
@@ -76,3 +76,6 @@ repos:
 
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
+
+  meta-clang:
+    url: "https://github.com/kraj/meta-clang.git"

--- a/kas/projects/tedge-p11-server.lock.yaml
+++ b/kas/projects/tedge-p11-server.lock.yaml
@@ -3,8 +3,8 @@ header:
 overrides:
   repos:
     poky:
-      commit: 553530a8acce3b078473c0fa512246a3e84d46bf
+      commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
     meta-openembedded:
-      commit: b4812b18eec77e9f0286bd6b81a5c3032ac0d3be
+      commit: 2b26d30fc7f478f5735d514f0c1bc28f6a4148b6
     meta-lts-mixins-rust:
       commit: 00c30d00f7377ee426b017bb46dd8c4c7eeea03b

--- a/kas/projects/tedge-rauc.lock.yaml
+++ b/kas/projects/tedge-rauc.lock.yaml
@@ -3,11 +3,11 @@ header:
 overrides:
   repos:
     poky:
-      commit: 553530a8acce3b078473c0fa512246a3e84d46bf
+      commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
     meta-raspberrypi:
       commit: 2c646d29912dcc873469a57b1c207e1549c5094d
     meta-openembedded:
-      commit: b4812b18eec77e9f0286bd6b81a5c3032ac0d3be
+      commit: 2b26d30fc7f478f5735d514f0c1bc28f6a4148b6
     meta-rauc:
       commit: a0f4a8b9986954239850b9d4256c003c91e6b931
     meta-rauc-community:
@@ -17,4 +17,6 @@ overrides:
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
     meta-virtualization:
-      commit: 17ac21e7d7f6f40a87618b22278b63bcfa14dbf2
+      commit: f92518e20530edfebca45e4170e11460949a5303
+    meta-clang:
+      commit: 5c602337ea1a80fb7217eeda04e396cf90587dca

--- a/kas/projects/tedge-rauc.yaml
+++ b/kas/projects/tedge-rauc.yaml
@@ -73,3 +73,6 @@ repos:
 
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
+
+  meta-clang:
+    url: "https://github.com/kraj/meta-clang.git"

--- a/kas/projects/tedge-rugix-tpm2.lock.yaml
+++ b/kas/projects/tedge-rugix-tpm2.lock.yaml
@@ -3,11 +3,11 @@ header:
 overrides:
   repos:
     poky:
-      commit: 553530a8acce3b078473c0fa512246a3e84d46bf
+      commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
     meta-raspberrypi:
       commit: 2c646d29912dcc873469a57b1c207e1549c5094d
     meta-openembedded:
-      commit: b4812b18eec77e9f0286bd6b81a5c3032ac0d3be
+      commit: 2b26d30fc7f478f5735d514f0c1bc28f6a4148b6
     meta-security:
       commit: afbbe28cee4af2c6760aaead43a4a3ef29969809
     meta-rugix:
@@ -17,4 +17,6 @@ overrides:
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
     meta-virtualization:
-      commit: 17ac21e7d7f6f40a87618b22278b63bcfa14dbf2
+      commit: f92518e20530edfebca45e4170e11460949a5303
+    meta-clang:
+      commit: 5c602337ea1a80fb7217eeda04e396cf90587dca

--- a/kas/projects/tedge-rugix-tpm2.yaml
+++ b/kas/projects/tedge-rugix-tpm2.yaml
@@ -80,3 +80,6 @@ repos:
 
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
+
+  meta-clang:
+    url: "https://github.com/kraj/meta-clang.git"

--- a/kas/projects/tedge-rugix.lock.yaml
+++ b/kas/projects/tedge-rugix.lock.yaml
@@ -3,11 +3,11 @@ header:
 overrides:
   repos:
     poky:
-      commit: 553530a8acce3b078473c0fa512246a3e84d46bf
+      commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
     meta-raspberrypi:
       commit: 2c646d29912dcc873469a57b1c207e1549c5094d
     meta-openembedded:
-      commit: b4812b18eec77e9f0286bd6b81a5c3032ac0d3be
+      commit: 2b26d30fc7f478f5735d514f0c1bc28f6a4148b6
     meta-rugix:
       commit: 22e60ef3aeb07f630af163a5ad1aef42ac8e97e6
     meta-lts-mixins-rust:
@@ -15,4 +15,6 @@ overrides:
     meta-lts-mixins-go:
       commit: 61f9b2720705cd68d9d6a96c11896f9ea20cfb13
     meta-virtualization:
-      commit: 17ac21e7d7f6f40a87618b22278b63bcfa14dbf2
+      commit: f92518e20530edfebca45e4170e11460949a5303
+    meta-clang:
+      commit: 5c602337ea1a80fb7217eeda04e396cf90587dca

--- a/kas/projects/tedge-rugix.yaml
+++ b/kas/projects/tedge-rugix.yaml
@@ -71,3 +71,6 @@ repos:
 
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
+
+  meta-clang:
+    url: "https://github.com/kraj/meta-clang.git"

--- a/meta-tedge/recipes-tedge/tedge/tedge-flows.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-flows.inc
@@ -1,0 +1,38 @@
+TEDGE_CONFIG_DIR ?= "/etc/tedge"
+
+do_install:append () {
+    install -d ${D}${TEDGE_CONFIG_DIR}/flows
+    install -d ${D}${datadir}/tedge/flows
+}
+
+FILES:${PN} += "\ 
+    ${TEDGE_CONFIG_DIR}/flows \
+    ${datadir}/tedge/flows \
+"
+
+# Required configurations to enable rquickjs bindgen
+DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
+inherit pkgconfig
+
+DEPENDS += " \
+    clang-native \
+"
+
+# Path to find libclang.so for the target system
+export LIBCLANG_PATH = "${STAGING_LIBDIR_NATIVE}"
+
+# Note: TARGET_SYS is not equals to RUST_TARGET_SYS. For example, they can be like below.
+#   TARGET_SYS="arm-poky-linux-gnueabi"
+#   RUST_TARGET_SYS="armv7-poky-linux-gnueabihf"
+# It seems rquickjs build.rs attempts bindgen for both host and target.
+# Use the target-specific variable to prevent sysroot paths from breaking the host-side compilation.
+python() {
+    # A target-specific BINDGEN_EXTRA_CLANG_ARGS requires underscore instead of hyphen as the system name
+    var_name = "BINDGEN_EXTRA_CLANG_ARGS_" + d.getVar('RUST_TARGET_SYS').replace('-', '_')
+    var_value = "-I${RECIPE_SYSROOT}/usr/include --target=${RUST_TARGET_SYS}"
+    d.setVar(var_name, var_value)
+    d.setVarFlag(var_name, 'export', '1')
+}
+
+# Force the bindgen feature enabled
+CARGO_BUILD_FLAGS:append = " --features rquickjs/bindgen"

--- a/meta-tedge/recipes-tedge/tedge/tedge.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge.inc
@@ -16,6 +16,9 @@ LICENSE = "Apache-2.0"
 
 inherit cargo-tedge tedge-user
 
+# Build only tedge, as tedge-p11-server is handled by a separate recipe
+CARGO_BUILD_FLAGS:append = " --bin tedge"
+
 RDEPENDS:${PN} = "${PN}-agent ${PN}-mapper-c8y ${PN}-mapper-aws ${PN}-mapper-az ${PN}-mapper-collectd mosquitto ca-certificates libgcc glibc-utils libxcrypt sudo"
 TEDGE_CONFIG_DIR ?= "/etc/tedge"
 TEDGE_CONFIG_SYMLINK ?= ""

--- a/meta-tedge/recipes-tedge/tedge/tedge_git.bb
+++ b/meta-tedge/recipes-tedge/tedge/tedge_git.bb
@@ -10,6 +10,5 @@ TEDGE_EXCLUDE = "c8y-firmware-plugin"
 require tedge.inc
 require tedge-diag.inc
 require tedge-log.inc
+require tedge-flows.inc
 
-# build tedge without tedge-flows due to an issue with rquickjs and bindgen
-CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "


### PR DESCRIPTION
This PR enables the `bindgen` feature of `rquickjs` crate and generates bindgen scripts during the compilation.

Several remarkable points:
- Clang is required, therefore, `meta-clang` layer is added.
- Specifying `LIBCLANG_PATH` is required to search `libclang.so` and other libclang related shared objects.
- `BINDGEN_EXTRA_CLANG_ARGS` is defined in [`rust-bindgen`](https://github.com/rust-lang/rust-bindgen). It supports per-target arguments as `BINDGEN_EXTRA_CLANG_ARGS_<TARGET>`. However, this `<TARGET>` must be _**underscore**_ separated triple. 
(e.g.  ✅ `armv7_poky_linux_gnueabihf`, ❌ `arm7-poky-linux-gnueabihf`)
- For some reason, `build.rs` of `quickjs` is also run for host system as well as the target system. To prevent confusion between two, `BINDGEN_EXTRA_CLANG_ARGS` needs to be defined per target...
- By default, bindgen cannot find the include directory of the target toolchains. If you don't add the specific include path, bindgen uses the host include path.
- `TARGET_SYS` from Yocto is NOT equal to `RUST_TARGET_SYS` from meta-lts-mixins-rust. (`arm-poky-linux-gnueabi` vs `armv7-poky-linux-gnueabihf`). Critically, the former indicates soft-float, while the latter does hard-float...

---

Successor of #380, #374.