### PR TITLE
chore(scarthgap): update admin.sh to reflect tedge-flows changes

### DIFF
--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-flows.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-flows.inc
@@ -1,0 +1,11 @@
+TEDGE_CONFIG_DIR ?= "/etc/tedge"
+
+do_install:append () {
+    install -d ${D}${TEDGE_CONFIG_DIR}/flows
+    install -d ${D}${datadir}/tedge/flows
+}
+
+FILES:${PN} += "\ 
+    ${TEDGE_CONFIG_DIR}/flows \
+    ${datadir}/tedge/flows \
+"

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-log.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-log.inc
@@ -1,0 +1,16 @@
+do_install:append () {
+    install -d ${D}${datadir}/tedge/log-plugins
+
+    install -m 0755 ${S}/configuration/contrib/log-plugins/dmesg ${D}${datadir}/tedge/log-plugins/
+    install -m 0755 ${S}/configuration/contrib/log-plugins/file ${D}${datadir}/tedge/log-plugins/
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -m 0755 ${S}/configuration/contrib/log-plugins/journald ${D}${datadir}/tedge/log-plugins/
+    fi
+}
+
+FILES:${PN} += "\
+    ${datadir}/tedge/log-plugins/dmesg \
+    ${datadir}/tedge/log-plugins/file \
+"
+FILES:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '${datadir}/tedge/log-plugins/journald', '', d)}"

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -108,6 +108,7 @@ SRC_URI[sysvinit.md5sum] = "$(get_services_checksum "$community_repo" "$services
 require tedge.inc
 require tedge-diag.inc
 require tedge-log.inc
+require tedge-flows.inc
 EOT
 
     #
@@ -148,9 +149,7 @@ TEDGE_EXCLUDE = "c8y-firmware-plugin"
 require tedge.inc
 require tedge-diag.inc
 require tedge-log.inc
-
-# build tedge without tedge-flows due to an issue with rquickjs and bindgen
-CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "
+require tedge-flows.inc
 EOT
 
     # Generate tedge-p11-server BB file
@@ -191,9 +190,7 @@ TEDGE_EXCLUDE = "c8y-firmware-plugin"
 require tedge.inc
 require tedge-diag.inc
 require tedge-log.inc
-
-# build tedge without tedge-flows due to an issue with rquickjs and bindgen
-CARGO_BUILD_FLAGS:append = " --bin tedge --features aws,azure,c8y --no-default-features "
+require tedge-flows.inc
 EOT
 
     tedge_p11_server_git_bb_file="meta-tedge/recipes-tedge/tedge-p11-server/tedge-p11-server_git.bb"


### PR DESCRIPTION
This is a follow-up PR of #387.

* Update `admin.sh` and add `tedge-flows.inc` in `meta-tedge-bin`, which #387 should have updated.
* In addition, add missing `tege-log.inc` in `meta-tedge-bin`.

Note: `meta-tedge-bin` is currently not buildable as it's missing `tedge-p11-server`. I will address it in another PR.