### PR TITLE
fix(kirkstone): fix build issues when using meta-tedge-bin layer

### DIFF
--- a/kas/config/skip-tedge-p11-server.yaml
+++ b/kas/config/skip-tedge-p11-server.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
+header:
+  version: 14
+
+bblayers_conf_header:
+  meta-skip-tedge-p11-server: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+
+local_conf_header:
+  meta-skip-tedge-p11-server: |
+    IMAGE_INSTALL:remove = " tedge-p11-server"

--- a/kas/projects/tedge-bin-rauc.yaml
+++ b/kas/projects/tedge-bin-rauc.yaml
@@ -10,6 +10,8 @@ header:
     - ../config/package-management.yaml
     - ../config/tedge-docker.yaml
     - ../config/tedge-nodered.yaml
+    # Note: tedge-p11-server is not yet available in the meta-tedge-bin layer
+    - ../config/skip-tedge-p11-server.yaml
 
 machine: raspberrypi-armv8
 distro: poky

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-config.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-config.inc
@@ -1,6 +1,6 @@
 do_install:append () {
     install -d ${D}${datadir}/tedge/config-plugins
-    install -m 0755 ${S}/configuration/contrib/config-plugins/file ${D}${datadir}/tedge/config-plugins/
+    install -m 0755 ${WORKDIR}/git/configuration/contrib/config-plugins/file ${D}${datadir}/tedge/config-plugins/
 }
 
 FILES:${PN} += "\

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-diag.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-diag.inc
@@ -1,6 +1,6 @@
 do_install:append () {
     install -d ${D}${datadir}/tedge/diag-plugins
-    install -m 0755 ${S}/configuration/contrib/diag-plugins/* ${D}${datadir}/tedge/diag-plugins/
+    install -m 0755 ${WORKDIR}/git/configuration/contrib/diag-plugins/* ${D}${datadir}/tedge/diag-plugins/
 }
 
 FILES:${PN} += "\

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-log.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-log.inc
@@ -1,11 +1,11 @@
 do_install:append () {
     install -d ${D}${datadir}/tedge/log-plugins
 
-    install -m 0755 ${S}/configuration/contrib/log-plugins/dmesg ${D}${datadir}/tedge/log-plugins/
-    install -m 0755 ${S}/configuration/contrib/log-plugins/file ${D}${datadir}/tedge/log-plugins/
+    install -m 0755 ${WORKDIR}/git/configuration/contrib/log-plugins/dmesg ${D}${datadir}/tedge/log-plugins/
+    install -m 0755 ${WORKDIR}/git/configuration/contrib/log-plugins/file ${D}${datadir}/tedge/log-plugins/
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
-        install -m 0755 ${S}/configuration/contrib/log-plugins/journald ${D}${datadir}/tedge/log-plugins/
+        install -m 0755 ${WORKDIR}/git/configuration/contrib/log-plugins/journald ${D}${datadir}/tedge/log-plugins/
     fi
 }
 

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.6.0.bb
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.6.0.bb
@@ -14,5 +14,10 @@ SRC_URI[openrc.md5sum] = "eda14cc61d3c1be5d7fd8ff9543fad07"
 SRC_URI[systemd.md5sum] = "2220a0eecd01da450176e60db2fef895"
 SRC_URI[sysvinit.md5sum] = "fc7a3913b556afd503717e4d457e65a8"
 
+# required for other files from the tedge source repo
+SRCREV_tedge = "a93d3fbcaf04c0a62cf4a1453309d72017c105f5"
+SRCREV_FORMAT = "tedge"
+SRC_URI += "git://git@github.com/thin-edge/thin-edge.io.git;protocol=https;branch=main;name=tedge"
+
 require tedge.inc
 require tedge-diag.inc

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.6.1.bb
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.6.1.bb
@@ -14,5 +14,10 @@ SRC_URI[openrc.md5sum] = "eda14cc61d3c1be5d7fd8ff9543fad07"
 SRC_URI[systemd.md5sum] = "2220a0eecd01da450176e60db2fef895"
 SRC_URI[sysvinit.md5sum] = "fc7a3913b556afd503717e4d457e65a8"
 
+# required for other files from the tedge source repo
+SRCREV_tedge = "e7c50099ce6b418c411e1ae049b3c6d997c18a1f"
+SRCREV_FORMAT = "tedge"
+SRC_URI += "git://git@github.com/thin-edge/thin-edge.io.git;protocol=https;branch=main;name=tedge"
+
 require tedge.inc
 require tedge-diag.inc

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.7.0.bb
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.7.0.bb
@@ -14,6 +14,11 @@ SRC_URI[openrc.md5sum] = "eda14cc61d3c1be5d7fd8ff9543fad07"
 SRC_URI[systemd.md5sum] = "2220a0eecd01da450176e60db2fef895"
 SRC_URI[sysvinit.md5sum] = "fc7a3913b556afd503717e4d457e65a8"
 
+# required for other files from the tedge source repo
+SRCREV_tedge = "404a0c54d811ae107c43b574a0829cc8fa5153e1"
+SRCREV_FORMAT = "tedge"
+SRC_URI += "git://git@github.com/thin-edge/thin-edge.io.git;protocol=https;branch=main;name=tedge"
+
 require tedge.inc
 require tedge-diag.inc
 require tedge-log.inc

--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.7.1.bb
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge_1.7.1.bb
@@ -14,4 +14,11 @@ SRC_URI[openrc.md5sum] = "eda14cc61d3c1be5d7fd8ff9543fad07"
 SRC_URI[systemd.md5sum] = "2220a0eecd01da450176e60db2fef895"
 SRC_URI[sysvinit.md5sum] = "fc7a3913b556afd503717e4d457e65a8"
 
+# checkout source
+SRCREV_tedge = "f743fa11586d4a3598bbe8ed951f66ab36bf0379"
+SRCREV_FORMAT = "tedge"
+SRC_URI += "git://git@github.com/thin-edge/thin-edge.io.git;protocol=https;branch=main;name=tedge"
+
 require tedge.inc
+require tedge-diag.inc
+require tedge-log.inc

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -69,55 +69,10 @@ update_version() {
         fi
     fi
 
-
-    #
-    # meta-tedge-bin
-    #
-    echo "--------------------------------------------" >&2
-    echo "Updating version on meta-tedge-bin" >&2
-    echo "--------------------------------------------" >&2
-    # thin-edge.io
+    # thin-edge.io meta information
     tedge_channel="release"
     tedge_version=$(get_latest_version "thinedge/tedge-release" "arm64")
     echo "Latest thin-edge.io version: $tedge_version in (thinedge/tedge-release)"
-
-    # tedge service definitions
-    community_repo="thinedge/community"
-    services_version=$(get_services_latest_version "$community_repo")
-    echo "Latest services repo version: $services_version in ($community_repo)"
-
-    # Generate BB file
-    tedge_bb_file="meta-tedge-bin/recipes-tedge/tedge-bin/tedge_${tedge_version}.bb"
-
-    echo "Writing bb file: $tedge_bb_file" >&2
-
-    cat << EOT | tee "$tedge_bb_file"
-# Architecture variables
-ARCH_REPO_CHANNEL = "$tedge_channel"
-ARCH_VERSION = "$tedge_version"
-SRC_URI[aarch64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "arm64" "$tedge_version")"
-SRC_URI[armv6.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}-armv6" "armv6" "$tedge_version")"
-SRC_URI[armv7.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "armv7" "$tedge_version")"
-SRC_URI[x86_64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "amd64" "$tedge_version")"
-SRC_URI[riscv64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "riscv64" "$tedge_version")"
-
-# Init manager variables
-INIT_REPO_CHANNEL = "$(basename "$community_repo")"
-INIT_VERSION = "$services_version"
-SRC_URI[openrc.md5sum] = "$(get_services_checksum "$community_repo" "$services_version" "tedge-openrc")"
-SRC_URI[systemd.md5sum] = "$(get_services_checksum "$community_repo" "$services_version" "tedge-systemd")"
-SRC_URI[sysvinit.md5sum] = "$(get_services_checksum "$community_repo" "$services_version" "tedge-sysvinit-yocto")"
-
-require tedge.inc
-EOT
-
-    #
-    # meta-tedge
-    #
-    echo >&2
-    echo "--------------------------------------------" >&2
-    echo "Updating version on meta-tedge" >&2
-    echo "--------------------------------------------" >&2
     JQ_QUERY=$(printf '.[] | select(.name == "%s") | [.name, .commit.sha] | @tsv' "$tedge_version")
     MATCHING_TAG=$(
         gh api \
@@ -136,6 +91,60 @@ EOT
 
     echo "Found tag: tag=$TAG, commit=$COMMIT_HASH" >&2
 
+    #
+    # meta-tedge-bin
+    #
+    echo "--------------------------------------------" >&2
+    echo "Updating version on meta-tedge-bin" >&2
+    echo "--------------------------------------------" >&2
+    # tedge service definitions
+    community_repo="thinedge/community"
+    services_version=$(get_services_latest_version "$community_repo")
+    echo "Latest services repo version: $services_version in ($community_repo)"
+
+    # Generate BB file
+    tedge_bb_file="meta-tedge-bin/recipes-tedge/tedge-bin/tedge_${tedge_version}.bb"
+    # Generate tedge BB file (if it doesn't already exist)
+    if [ "$FORCE_OVERWRITE" = 1 ] || [ ! -f "$tedge_bb_file" ]; then
+        echo "Writing bb file: $tedge_bb_file" >&2
+
+        cat << EOT | tee "$tedge_bb_file"
+# Architecture variables
+ARCH_REPO_CHANNEL = "$tedge_channel"
+ARCH_VERSION = "$tedge_version"
+SRC_URI[aarch64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "arm64" "$tedge_version")"
+SRC_URI[armv6.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}-armv6" "armv6" "$tedge_version")"
+SRC_URI[armv7.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "armv7" "$tedge_version")"
+SRC_URI[x86_64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "amd64" "$tedge_version")"
+SRC_URI[riscv64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "riscv64" "$tedge_version")"
+
+# Init manager variables
+INIT_REPO_CHANNEL = "$(basename "$community_repo")"
+INIT_VERSION = "$services_version"
+SRC_URI[openrc.md5sum] = "$(get_services_checksum "$community_repo" "$services_version" "tedge-openrc")"
+SRC_URI[systemd.md5sum] = "$(get_services_checksum "$community_repo" "$services_version" "tedge-systemd")"
+SRC_URI[sysvinit.md5sum] = "$(get_services_checksum "$community_repo" "$services_version" "tedge-sysvinit-yocto")"
+
+# checkout source
+SRCREV_tedge = "$COMMIT_HASH"
+SRCREV_FORMAT = "tedge"
+SRC_URI += "git://git@github.com/thin-edge/thin-edge.io.git;protocol=https;branch=main;name=tedge"
+
+require tedge.inc
+require tedge-diag.inc
+require tedge-log.inc
+EOT
+    else
+        printf 'bb recipe already exists: %s\n\n' "$tedge_bb_file"
+    fi
+
+    #
+    # meta-tedge
+    #
+    echo >&2
+    echo "--------------------------------------------" >&2
+    echo "Updating version on meta-tedge" >&2
+    echo "--------------------------------------------" >&2
     tedge_bb_file="meta-tedge/recipes-tedge/tedge/tedge_${tedge_version}.bb"
     # Generate tedge BB file (if it doesn't already exist)
     if [ "$FORCE_OVERWRITE" = 1 ] || [ ! -f "$tedge_bb_file" ]; then


### PR DESCRIPTION
Fix the the following issues which previously blocked the tedge-bin-rauc.yaml kas project from building:

* Skip installing the tedge-p11-server when using the meta-tedge-bin layer as there isn't a recipe for it yet
* Add support for copying files from the thin-edge.io git repository (as these files are referenced in the tedge-diag, tedge-logs include files)
* Update the admin.sh script to get the meta information before generating the meta-tedge-bin recipe as it now references the commit hash requires to copy extra configuration files from it

Note: The PR checks don't test the building of this project, however the following build was manually executed locally to verify the fix:

```sh
just build-project ./projects/tedge-bin-rauc.yaml
```

Resolves https://github.com/thin-edge/meta-tedge/issues/399