### PR TITLE
ci(scarthgap): add block fixup in pull request check

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -1,0 +1,20 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  block-fixup:
+    name: Block fixup commits
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Block Fixup Commit Merge
+        # https://github.com/13rac1/block-fixup-merge-action
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Block fixup commits to be merged using GitHub Actions for pull requests. The same action as we use in our main thin-edge.io repository.

Port the same script from https://github.com/thin-edge/tedge-flows-examples/pull/57.