### PR TITLE
refactor(scarthgap): simplify tedge-diag.inc

### DIFF
--- a/meta-tedge/recipes-tedge/tedge/tedge-diag.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-diag.inc
@@ -3,13 +3,4 @@ do_install:append () {
     install -m 0755 ${S}/configuration/contrib/diag-plugins/* ${D}${datadir}/tedge/diag-plugins/
 }
 
-FILES:${PN} += "\
-    ${datadir}/tedge/diag-plugins/01_tedge.sh \
-    ${datadir}/tedge/diag-plugins/02_os.sh \
-    ${datadir}/tedge/diag-plugins/03_mqtt.sh \
-    ${datadir}/tedge/diag-plugins/04_workflow.sh \
-    ${datadir}/tedge/diag-plugins/05_entities.sh \
-    ${datadir}/tedge/diag-plugins/06_internal.sh \
-    ${datadir}/tedge/diag-plugins/07_mosquitto.sh \
-    ${datadir}/tedge/diag-plugins/template.sh.ignore \
-"
+FILES:${PN} += "${datadir}/tedge/diag-plugins/*"


### PR DESCRIPTION
With current `tedge-diag.inc`, the validation check fails as the `08_truststore.sh` file is not included, which is added by https://github.com/thin-edge/thin-edge.io/pull/3944.
Since we will most probably add more diag plugins in the future and don't want to add a new file every time, simplify the `tedge-diag.inc` file to contain all the files.