### PR TITLE
chore(scarthgap): add --insecure-skip-bundle-verification to rugix workflow script

### DIFF
--- a/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/rugix_workflow.sh
+++ b/meta-tedge-rugix/recipes-tedge/tedge-firmware-rugix/tedge-firmware-rugix/rugix_workflow.sh
@@ -288,16 +288,16 @@ install() {
         http://*|https://*)
             if [ "$STREAM_DOWNLOAD" = 1 ]; then
                 log "Downloading and streaming image to rugix"
-                download_file "$url" | $SUDO rugix-ctrl update install --reboot no -
+                download_file "$url" | $SUDO rugix-ctrl update install --insecure-skip-bundle-verification --reboot no -
             else
                 log "Downloading image using rugix"
-                $SUDO rugix-ctrl update install --reboot no "$url"
+                $SUDO rugix-ctrl update install --insecure-skip-bundle-verification --reboot no "$url"
             fi
             ;;
         *)
             # It is a file
             log "Installing local image to rugix"
-            $SUDO rugix-ctrl update install --reboot no "$url"
+            $SUDO rugix-ctrl update install --insecure-skip-bundle-verification --reboot no "$url"
             ;;
     esac
     EXIT_CODE=$?


### PR DESCRIPTION
This PR adds `--insecure-skip-bundle-verification` to `rugix_workflow.sh`.

Since Rugix introduced [image verification](https://rugix.org/docs/getting-started/#installing-an-update), without this option, updating rugix image will fail due to missing signature. Until we add a signing mechanism, we should keep this option.