### PR TITLE
chore(scarthgap): create <config-dir>/mappers/local/flows directory owned by tedge

### DIFF
--- a/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-flows.inc
+++ b/meta-tedge-bin/recipes-tedge/tedge-bin/tedge-flows.inc
@@ -2,6 +2,7 @@ TEDGE_CONFIG_DIR ?= "/etc/tedge"
 
 do_install:append () {
     install -d ${D}${TEDGE_CONFIG_DIR}/mappers/local/flows
+    chown -R tedge:tedge "${D}${TEDGE_CONFIG_DIR}"/mappers
 }
 
 FILES:${PN} += "\ 

--- a/meta-tedge/recipes-tedge/tedge/tedge-flows.inc
+++ b/meta-tedge/recipes-tedge/tedge/tedge-flows.inc
@@ -2,10 +2,11 @@ TEDGE_CONFIG_DIR ?= "/etc/tedge"
 
 do_install:append () {
     install -d ${D}${TEDGE_CONFIG_DIR}/mappers/local/flows
+    chown -R tedge:tedge "${D}${TEDGE_CONFIG_DIR}"/mappers
 }
 
 FILES:${PN} += "\ 
-    ${TEDGE_CONFIG_DIR}/mapppers/local/flows \
+    ${TEDGE_CONFIG_DIR}/mappers/local/flows \
 "
 
 # Required configurations to enable rquickjs bindgen


### PR DESCRIPTION
This PR adds a recipe to create `/etc/tedge/mappers/local/flows` directory owned by `tedge:tedge`.

Verified on RPi4.
```
root@rpi4-dca632d63cc9:~# cd /etc/tedge/
root@rpi4-dca632d63cc9:tedge# ls -ltr
total 36
-rw-r--r--    1 root     root            60 Mar  9  2018 system.toml
drwxrwxr-x    2 tedge    tedge         4096 Mar  9  2018 sm-plugins
drwxr-xr-x    2 tedge    tedge         4096 Mar  9  2018 device
-rw-r--r--    1 tedge    tedge          285 Apr  1 17:02 tedge.toml
drwxrwxr-x    2 tedge    tedge         4096 Apr  1 17:02 device-certs
drwxrwxr-x    2 tedge    tedge         4096 Apr  1 17:02 mosquitto-conf
drwxrwxr-x    4 tedge    tedge         4096 Apr  1 17:02 mappers
drwxrwxr-x    2 tedge    tedge         4096 Apr  1 17:02 plugins
drwxrwxr-x    3 tedge    tedge         4096 Apr  1 17:02 operations
root@rpi4-dca632d63cc9:tedge# cd mappers
root@rpi4-dca632d63cc9:mappers# ls -ltr
total 8
drwxr-xr-x    3 tedge    tedge         4096 Mar  9  2018 local
drwxr-xr-x    3 tedge    tedge         4096 Apr  1 17:02 c8y
root@rpi4-dca632d63cc9:mappers# cd local
root@rpi4-dca632d63cc9:local# ls -ltr
total 4
drwxr-xr-x    2 tedge    tedge         4096 Mar  9  2018 flows
```

```
root@rpi4-dca632d63cc9:local# tedge flows list
Error: failed to list flows and flow steps in /etc/tedge/mappers/local/flows

Caused by:
    No valid flows
```

---

✅  Build passed for the upstream main branch: https://github.com/thin-edge/meta-tedge/actions/runs/23860884461?pr=453