### PR TITLE
ci(scarthgap): update github actions to resolve nodejs 20 deprecation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -104,7 +104,7 @@ jobs:
           find "kas/build/tmp/deploy/images/${{ matrix.machine }}/" -type l -name "${{ matrix.image_name }}*" -delete
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.image_name }}_${{ matrix.machine }}
           path: |

--- a/.github/workflows/check_updates.yaml
+++ b/.github/workflows/check_updates.yaml
@@ -22,6 +22,6 @@ jobs:
           - kirkstone
           - scarthgap
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update ${{ matrix.branch }}
         run: gh workflow run update --ref ${{ matrix.branch }}

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Block Fixup Commit Merge
         # https://github.com/13rac1/block-fixup-merge-action

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -14,7 +14,7 @@ jobs:
       PR_BRANCH: updater-${{github.ref_name}}
       TARGET_BRANCH: ${{github.ref_name}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Only install tooling if not running on a self-hosted runner as the tools are already pre-installed
       - uses: taiki-e/install-action@just


### PR DESCRIPTION
Remove the node.js 20 deprecation warnings from GitHub Actions workflows.

There are 8 warnings [here](https://github.com/thin-edge/meta-tedge/actions/runs/24660727278).

> [Build tedge-rauc raspberrypi](https://github.com/thin-edge/meta-tedge/actions/runs/24660727278/job/72105878116#step:17:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/