### PR TITLE
ci(kirkstone): update github actions to resolve nodejs 20 deprecation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -104,7 +104,7 @@ jobs:
           find "kas/build/tmp/deploy/images/${{ matrix.machine }}/" -type l -name "${{ matrix.image_name }}*" -delete
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.image_name }}_${{ matrix.machine }}
           path: |

--- a/.github/workflows/check_updates.yaml
+++ b/.github/workflows/check_updates.yaml
@@ -22,6 +22,6 @@ jobs:
           - kirkstone
           - scarthgap
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update ${{ matrix.branch }}
         run: gh workflow run update --ref ${{ matrix.branch }}

--- a/.github/workflows/clean.yaml
+++ b/.github/workflows/clean.yaml
@@ -59,7 +59,7 @@ jobs:
       - X64
       - offsite_yocto
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Disk space (before)
         run: df -h /
       - name: Remove old SSTATE files

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Block Fixup Commit Merge
         # https://github.com/13rac1/block-fixup-merge-action

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -14,7 +14,7 @@ jobs:
       PR_BRANCH: updater-${{github.ref_name}}
       TARGET_BRANCH: ${{github.ref_name}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Only install tooling if not running on a self-hosted runner as the tools are already pre-installed
       - uses: taiki-e/install-action@just


### PR DESCRIPTION
Remove node.js 20 deprecation warnings from GitHub Actions. Example warning: https://github.com/thin-edge/meta-tedge/actions/runs/24705534640