### PR TITLE
ci: rewrite git protocol to use https instead of git

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,6 +82,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Rewrite git protocol to https
+        run: git config --global url."https://".insteadOf git://
+
       # Only install tooling if not running on a self-hosted runner as the tools are already pre-installed
       - uses: taiki-e/install-action@just
         if: ${{ !startsWith(runner.name, 'tedge') }}


### PR DESCRIPTION
Our build server has a problem to clone some repositories. [example](https://github.com/thin-edge/meta-tedge/actions/runs/26579169682/job/78505552686).

```
2026-05-29 13:09:23 - ERROR    - Command "/home/octocat/actions-runner/_work/meta-tedge/meta-tedge/kas/_kas$ git clone -q git://git.yoctoproject.org/meta-security /home/octocat/actions-runner/_work/meta-tedge/meta-tedge/kas/_kas/meta-security" failed
--- Error summary ---
fatal: unable to connect to git.yoctoproject.org:
git.yoctoproject.org[0: 104.18.1.115]: errno=Connection timed out
git.yoctoproject.org[1: 104.18.0.115]: errno=Connection timed out
git.yoctoproject.org[2: 2606:4700::6812:173]: errno=Network is unreachable
git.yoctoproject.org[3: 2606:4700::6812:73]: errno=Network is unreachable
2026-05-29 13:09:23 - ERROR    - fetch repos failed: error code 128
error: Recipe `build-project` failed on line 40 with exit code 2
Error: Process completed with exit code 2.
```

To avoid firewall for the port `9418` for `git` protocol,  this git config change forces to use `https`.