### PR TITLE
fix(scarthgap): update meta-security URL to use HTTPS protocol

### DIFF
--- a/kas/config/raspberrypi-tpm2.yaml
+++ b/kas/config/raspberrypi-tpm2.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/66261547b75885786777a0b9c8a4400ab81d432e/kas/schema-kas.json
 # Note: This configuration requires the following layer to be added
 # meta-security:
-#     url: "git://git.yoctoproject.org/meta-security"
+#     url: "https://git.yoctoproject.org/meta-security"
 #     layers:
 #       .:
 #       meta-tpm:

--- a/kas/projects/tedge-mender-tpm2.yaml
+++ b/kas/projects/tedge-mender-tpm2.yaml
@@ -47,7 +47,7 @@ repos:
 
   # Required for tpm2
   meta-security:
-    url: "git://git.yoctoproject.org/meta-security"
+    url: "https://git.yoctoproject.org/meta-security"
     layers:
       .:
       meta-tpm:

--- a/kas/projects/tedge-rauc-tpm2.yaml
+++ b/kas/projects/tedge-rauc-tpm2.yaml
@@ -49,7 +49,7 @@ repos:
 
   # Required for tpm2
   meta-security:
-    url: "git://git.yoctoproject.org/meta-security"
+    url: "https://git.yoctoproject.org/meta-security"
     layers:
       .:
       meta-tpm:

--- a/kas/projects/tedge-rugix-tpm2.yaml
+++ b/kas/projects/tedge-rugix-tpm2.yaml
@@ -49,7 +49,7 @@ repos:
 
   # Required for tpm2
   meta-security:
-    url: "git://git.yoctoproject.org/meta-security"
+    url: "https://git.yoctoproject.org/meta-security"
     layers:
       .:
       meta-tpm:


### PR DESCRIPTION
This is a proper way to fix the issue occurred in our build server.

---

Our build server has a problem to clone some repositories. [example](https://github.com/thin-edge/meta-tedge/actions/runs/26579169682/job/78505552686).

```
2026-05-29 13:09:23 - ERROR    - Command "/home/octocat/actions-runner/_work/meta-tedge/meta-tedge/kas/_kas$ git clone -q git://git.yoctoproject.org/meta-security /home/octocat/actions-runner/_work/meta-tedge/meta-tedge/kas/_kas/meta-security" failed
--- Error summary ---
fatal: unable to connect to git.yoctoproject.org:
git.yoctoproject.org[0: 104.18.1.115]: errno=Connection timed out
git.yoctoproject.org[1: 104.18.0.115]: errno=Connection timed out
git.yoctoproject.org[2: 2606:4700::6812:173]: errno=Network is unreachable
git.yoctoproject.org[3: 2606:4700::6812:73]: errno=Network is unreachable
2026-05-29 13:09:23 - ERROR    - fetch repos failed: error code 128
error: Recipe `build-project` failed on line 40 with exit code 2
Error: Process completed with exit code 2.
```